### PR TITLE
Revamp pricing page

### DIFF
--- a/backend/src/assets/css/pricing.css
+++ b/backend/src/assets/css/pricing.css
@@ -1,3 +1,31 @@
-.pricing-switch {
+.period-toggle {
   margin-bottom: 20px;
+}
+
+.plan-card {
+  transition: box-shadow 0.3s ease, transform 0.3s ease;
+}
+
+.plan-card:hover {
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.1);
+  transform: translateY(-3px);
+}
+
+.plan-features {
+  list-style: none;
+  padding-left: 0;
+}
+
+.feature-disabled {
+  color: #9ca3af;
+  text-decoration: line-through;
+}
+
+.feature-check {
+  color: #22C55E;
+}
+
+.best-choice {
+  background-color: #F97316 !important;
+  color: #fff !important;
 }

--- a/backend/src/pages/Pricing.tsx
+++ b/backend/src/pages/Pricing.tsx
@@ -8,11 +8,18 @@ import {
   CardContent,
   CardActions,
   Button,
-  Switch,
-  FormControlLabel,
-  RadioGroup,
-  Radio,
+  ToggleButtonGroup,
+  ToggleButton,
+  Chip,
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
 } from '@mui/material'
+import {
+  Check as CheckIcon,
+  Close as CloseIcon,
+} from '@mui/icons-material'
 import { useNavigate } from 'react-router-dom'
 import Layout from '@/components/Layout'
 import * as bookcarsTypes from ':bookcars-types'
@@ -21,93 +28,136 @@ import '@/assets/css/pricing.css'
 const Pricing = () => {
   const navigate = useNavigate()
   const [period, setPeriod] = useState<bookcarsTypes.SubscriptionPeriod>('monthly' as bookcarsTypes.SubscriptionPeriod)
-  const [plan, setPlan] = useState<bookcarsTypes.SubscriptionPlan>('free' as bookcarsTypes.SubscriptionPlan)
 
-  const handleToggle = (_: React.ChangeEvent<HTMLInputElement>, checked: boolean) => {
-    setPeriod(checked ? ('yearly' as bookcarsTypes.SubscriptionPeriod) : ('monthly' as bookcarsTypes.SubscriptionPeriod))
+  const handlePeriodChange = (_: React.MouseEvent<HTMLElement>, value: bookcarsTypes.SubscriptionPeriod | null) => {
+    if (value) {
+      setPeriod(value)
+    }
   }
 
-  const handlePlanChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setPlan(e.target.value as bookcarsTypes.SubscriptionPlan)
-  }
-
-  const handlePay = () => {
-    navigate(`/pricing/checkout?plan=${plan}&period=${period}`)
-  }
 
   const prices = {
     free: { monthly: 0, yearly: 0 },
-    basic: { monthly: 10, yearly: 100 },
-    premium: { monthly: 30, yearly: 290 },
+    basic: { monthly: 10, yearly: 96 },
+    premium: { monthly: 30, yearly: 288 },
+  }
+
+  const features = [
+    { label: 'Voitures visibles dans les résultats', free: '1', basic: '3', premium: 'Illimité' },
+    { label: 'Voitures sponsorisées', free: false, basic: '1', premium: 'Illimité' },
+    { label: 'URL personnalisée', free: false, basic: true, premium: true },
+    { label: 'Page agence dédiée', free: false, basic: false, premium: true },
+    { label: 'Statistiques de vues', free: false, basic: false, premium: true },
+    { label: 'Gestion d\u2019annonces (dupliquer, masquer\u2026)', free: false, basic: false, premium: true },
+    { label: 'Support par email et chat', free: false, basic: true, premium: true },
+    { label: 'Badge \u201cAgence v\u00E9rifi\u00E9e\u201d', free: false, basic: false, premium: true },
+    { label: 'Acc\u00E8s aux factures PDF', free: false, basic: true, premium: true },
+    { label: 'Calendrier de disponibilit\u00E9', free: false, basic: 'extra', premium: true },
+    { label: 'Essai gratuit 14 jours', free: false, basic: true, premium: true },
+  ]
+
+  const renderFeature = (feature: any, _plan: bookcarsTypes.SubscriptionPlan) => {
+    const value = feature[_plan]
+    const active = value && value !== 'extra'
+    const extra = value === 'extra'
+    return (
+      <ListItem className={!active && !extra ? 'feature-disabled' : ''}>
+        <ListItemIcon>
+          {active ? <CheckIcon className="feature-check" /> : <CloseIcon color="disabled" />}
+        </ListItemIcon>
+        <ListItemText primary={`${feature.label}${typeof value === 'string' && value !== 'extra' && value !== 'true' ? `: ${value}` : ''}${extra ? ' (+5DT/mois)' : ''}`} />
+      </ListItem>
+    )
+  }
+
+  const plans = [
+    {
+      id: 'free',
+      name: 'Free Plan',
+      color: '#9ca3af',
+      hover: '#6b7280',
+      cta: 'Choisir',
+    },
+    {
+      id: 'basic',
+      name: 'Basic Plan',
+      color: '#3B82F6',
+      hover: '#1d4ed8',
+      cta: 'Essayer gratuitement',
+    },
+    {
+      id: 'premium',
+      name: 'Premium Plan',
+      color: '#F97316',
+      hover: '#c2410c',
+      cta: 'Essayer gratuitement',
+      badge: true,
+    },
+  ] as const
+
+  const handleChoose = (p: bookcarsTypes.SubscriptionPlan) => {
+    navigate(`/pricing/checkout?plan=${p}&period=${period}`)
   }
 
   return (
     <Layout strict>
       <Container maxWidth="lg">
         <Box my={4} textAlign="center">
-          <Typography variant="h4" gutterBottom>Tarification</Typography>
-          <FormControlLabel
-            control={<Switch checked={period === 'yearly'} onChange={handleToggle} />}
-            label={period === 'monthly' ? 'Mensuel' : 'Annuel'}
-          />
+          <Typography variant="h4" gutterBottom>
+            Plans adaptés à vos besoins
+          </Typography>
+          <Typography variant="subtitle1" gutterBottom>
+            Essayez gratuitement pendant 14 jours. Aucune carte bancaire nécessaire.
+          </Typography>
+          <ToggleButtonGroup
+            exclusive
+            value={period}
+            onChange={handlePeriodChange}
+            className="period-toggle"
+            sx={{ mb: 2 }}
+          >
+            <ToggleButton value="monthly">Mensuel</ToggleButton>
+            <ToggleButton value="yearly">Annuel</ToggleButton>
+          </ToggleButtonGroup>
+          {period === 'yearly' && (
+            <Typography variant="caption" color="textSecondary" display="block">
+              Économisez 20%
+            </Typography>
+          )}
         </Box>
-        <RadioGroup row value={plan} onChange={handlePlanChange}>
-          <Grid container spacing={3} justifyContent="center">
-            <Grid item xs={12} md={4}>
-              <Card variant="outlined">
+
+        <Grid container spacing={3} justifyContent="center">
+          {plans.map((p) => (
+            <Grid item xs={12} md={4} key={p.id}>
+              <Card className="plan-card" variant="outlined" sx={{ position: 'relative' }}>
+                {p.badge && (
+                  <Chip label="Meilleur choix" size="small" className="best-choice" sx={{ position: 'absolute', top: 16, right: 16 }} />
+                )}
                 <CardContent>
-                  <Typography variant="h5" gutterBottom>Free Plan</Typography>
-                  <Typography variant="h6" color="primary">
-                    {prices.free[period]}
-                    DT/
-                    {period === 'monthly' ? 'mois' : 'an'}
+                  <Typography variant="h6" gutterBottom align="center">
+                    {p.name}
                   </Typography>
-                  <Typography variant="body2">1 voiture affichée dans les résultats</Typography>
+                  <Typography variant="h4" align="center" gutterBottom>
+                    {prices[p.id as keyof typeof prices][period]}DT
+                    <Typography component="span" variant="subtitle2">/{period === 'monthly' ? 'mois' : 'an'}</Typography>
+                  </Typography>
+                  <List className="plan-features">
+                    {features.map((f) => renderFeature(f, p.id as bookcarsTypes.SubscriptionPlan))}
+                  </List>
                 </CardContent>
-                <CardActions>
-                  <FormControlLabel value="free" control={<Radio />} label="Choisir" />
+                <CardActions sx={{ justifyContent: 'center' }}>
+                  <Button
+                    variant="contained"
+                    onClick={() => handleChoose(p.id as bookcarsTypes.SubscriptionPlan)}
+                    sx={{ backgroundColor: p.color, '&:hover': { backgroundColor: p.hover } }}
+                  >
+                    {p.cta}
+                  </Button>
                 </CardActions>
               </Card>
             </Grid>
-            <Grid item xs={12} md={4}>
-              <Card variant="outlined">
-                <CardContent>
-                  <Typography variant="h5" gutterBottom>Basic Plan</Typography>
-                  <Typography variant="h6" color="primary">
-                    {prices.basic[period]}
-                    DT/
-                    {period === 'monthly' ? 'mois' : 'an'}
-                  </Typography>
-                  <Typography variant="body2">3 voitures dans les résultats + 1 sponsorisée</Typography>
-                </CardContent>
-                <CardActions>
-                  <FormControlLabel value="basic" control={<Radio />} label="Choisir" />
-                </CardActions>
-              </Card>
-            </Grid>
-            <Grid item xs={12} md={4}>
-              <Card variant="outlined">
-                <CardContent>
-                  <Typography variant="h5" gutterBottom>Premium Plan</Typography>
-                  <Typography variant="h6" color="primary">
-                    {prices.premium[period]}
-                    DT/
-                    {period === 'monthly' ? 'mois' : 'an'}
-                  </Typography>
-                  <Typography variant="body2">Toutes les voitures dans les résultats + 3 sponsorisées</Typography>
-                </CardContent>
-                <CardActions>
-                  <FormControlLabel value="premium" control={<Radio />} label="Choisir" />
-                </CardActions>
-              </Card>
-            </Grid>
-          </Grid>
-        </RadioGroup>
-        <Box mt={4} textAlign="center">
-          <Button variant="contained" className="btn-primary" onClick={handlePay}>
-            Payer
-          </Button>
-        </Box>
+          ))}
+        </Grid>
       </Container>
     </Layout>
   )


### PR DESCRIPTION
## Summary
- modernize pricing page design
- add interactive plan cards and yearly switch
- style pricing elements with new CSS

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run stylelint` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_e_687027c4965c8333972e054ddbd0b03a