### PR TITLE
Fix subscription upgrade logic and pricing

### DIFF
--- a/api/src/controllers/subscriptionController.ts
+++ b/api/src/controllers/subscriptionController.ts
@@ -14,7 +14,22 @@ import * as env from '../config/env.config'
 export const create = async (req: Request, res: Response) => {
   try {
     const data: bookcarsTypes.CreateSubscriptionPayload = req.body
-    const subscription = new Subscription(data)
+    const now = new Date()
+    let subscription = await Subscription.findOne({
+      supplier: data.supplier,
+      endDate: { $gt: now },
+    }).sort({ endDate: -1 })
+
+    if (subscription) {
+      subscription.plan = data.plan
+      subscription.period = data.period
+      subscription.endDate = data.endDate
+      subscription.resultsCars = data.resultsCars
+      subscription.sponsoredCars = data.sponsoredCars
+    } else {
+      subscription = new Subscription(data)
+    }
+
     subscription.invoice = `invoice_${subscription._id}.pdf`
     await subscription.save()
 

--- a/api/tests/subscription-price.test.ts
+++ b/api/tests/subscription-price.test.ts
@@ -1,0 +1,57 @@
+import 'dotenv/config'
+import { calculateSubscriptionFinalPrice } from '../../packages/bookcars-helper'
+import * as bookcarsTypes from ':bookcars-types'
+
+describe('calculateSubscriptionFinalPrice', () => {
+  beforeAll(() => {
+    jest.useFakeTimers()
+  })
+
+  afterAll(() => {
+    jest.useRealTimers()
+  })
+
+  it('should compute remaining credit for 31-day month', () => {
+    jest.setSystemTime(new Date('2025-01-15T00:00:00Z'))
+    const sub: bookcarsTypes.Subscription = {
+      supplier: 's',
+      plan: bookcarsTypes.SubscriptionPlan.Basic,
+      period: bookcarsTypes.SubscriptionPeriod.Monthly,
+      startDate: new Date('2025-01-01T00:00:00Z'),
+      endDate: new Date('2025-02-01T00:00:00Z'),
+      resultsCars: 3,
+      sponsoredCars: 1,
+    }
+    const final = calculateSubscriptionFinalPrice(
+      sub,
+      bookcarsTypes.SubscriptionPlan.Premium,
+      bookcarsTypes.SubscriptionPeriod.Monthly,
+    )
+    const totalDays = 31
+    const remainingDays = 17
+    const expected = 30 - (remainingDays / totalDays) * 10
+    expect(final).toBeCloseTo(expected)
+  })
+
+  it('should compute remaining credit for 28-day month', () => {
+    jest.setSystemTime(new Date('2025-02-10T00:00:00Z'))
+    const sub: bookcarsTypes.Subscription = {
+      supplier: 's',
+      plan: bookcarsTypes.SubscriptionPlan.Basic,
+      period: bookcarsTypes.SubscriptionPeriod.Monthly,
+      startDate: new Date('2025-02-01T00:00:00Z'),
+      endDate: new Date('2025-03-01T00:00:00Z'),
+      resultsCars: 3,
+      sponsoredCars: 1,
+    }
+    const final = calculateSubscriptionFinalPrice(
+      sub,
+      bookcarsTypes.SubscriptionPlan.Premium,
+      bookcarsTypes.SubscriptionPeriod.Monthly,
+    )
+    const totalDays = 28
+    const remainingDays = 20
+    const expected = 30 - (remainingDays / totalDays) * 10
+    expect(final).toBeCloseTo(expected)
+  })
+})

--- a/api/tests/subscription.test.ts
+++ b/api/tests/subscription.test.ts
@@ -72,6 +72,33 @@ describe('POST /api/create-subscription', () => {
     expect(sub?.sponsoredCars).toBe(1)
     await testHelper.signout(token)
   })
+
+  it('should update the current subscription when called twice', async () => {
+    const first = await Subscription.findOne({ supplier: SUPPLIER_ID }).lean()
+    expect(first).toBeTruthy()
+
+    const token = await signin(SUPPLIER_EMAIL)
+    const payload: bookcarsTypes.CreateSubscriptionPayload = {
+      supplier: SUPPLIER_ID,
+      plan: bookcarsTypes.SubscriptionPlan.Premium,
+      period: bookcarsTypes.SubscriptionPeriod.Monthly,
+      startDate: new Date('2025-05-01'),
+      endDate: new Date('2025-07-01'),
+      resultsCars: -1,
+      sponsoredCars: -1,
+    }
+    const res = await request(app)
+      .post('/api/create-subscription')
+      .set(env.X_ACCESS_TOKEN, token)
+      .send(payload)
+    expect(res.statusCode).toBe(200)
+
+    const subs = await Subscription.find({ supplier: SUPPLIER_ID }).lean()
+    expect(subs.length).toBe(1)
+    expect(subs[0]._id.toString()).toBe(first!._id.toString())
+    expect(subs[0].plan).toBe(bookcarsTypes.SubscriptionPlan.Premium)
+    await testHelper.signout(token)
+  })
 })
 
 describe('GET /api/my-subscription', () => {

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -31,7 +31,8 @@
     "baseUrl": "./",                                     /* Specify the base directory to resolve non-relative module names. */
     "paths": {
       // "@/*": ["./src/*"],
-      ":bookcars-types": ["../packages/bookcars-types"]
+      ":bookcars-types": ["../packages/bookcars-types"],
+      ":bookcars-helper": ["../packages/bookcars-helper"]
     },                                                   /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
@@ -114,6 +115,7 @@
     "node_modules"
   ],
   "references": [
-    { "path": "../packages/bookcars-types" }
+    { "path": "../packages/bookcars-types" },
+    { "path": "../packages/bookcars-helper" }
   ],
 }


### PR DESCRIPTION
## Summary
- prevent duplicate subscriptions by updating the current one when active
- disable multiple checkout submissions and refresh data
- compute upgrade credit using real period length
- expose calculation helper and use it from frontend
- test subscription updates and price calculation
- update tsconfig paths for helper package

## Testing
- `npm test` *(fails: rimraf not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b76b3e0388333b9d28aa471944120