### PR TITLE
Fix missing helper export

### DIFF
--- a/api/tests/subscription-price.test.ts
+++ b/api/tests/subscription-price.test.ts
@@ -1,5 +1,5 @@
 import 'dotenv/config'
-import { calculateSubscriptionFinalPrice } from '../../packages/bookcars-helper'
+import { calculateSubscriptionFinalPrice } from '../../packages/bookcars-helper/index.ts'
 import * as bookcarsTypes from ':bookcars-types'
 
 describe('calculateSubscriptionFinalPrice', () => {

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -32,7 +32,7 @@
     "paths": {
       // "@/*": ["./src/*"],
       ":bookcars-types": ["../packages/bookcars-types"],
-      ":bookcars-helper": ["../packages/bookcars-helper"]
+      ":bookcars-helper": ["../packages/bookcars-helper/index.ts"]
     },                                                   /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -23,7 +23,7 @@
     "paths": {
       "@/*": ["./src/*"],
       ":bookcars-types": ["../packages/bookcars-types"],
-      ":bookcars-helper": ["../packages/bookcars-helper"],
+      ":bookcars-helper": ["../packages/bookcars-helper/index.ts"],
       ":disable-react-devtools": ["../packages/disable-react-devtools"]
     },
   },

--- a/backend/vite.config.ts
+++ b/backend/vite.config.ts
@@ -13,7 +13,7 @@ export default ({ mode }: { mode: string }) => {
       alias: {
         '@': path.resolve(__dirname, './src'),
         ':bookcars-types': path.resolve(__dirname, '../packages/bookcars-types'),
-        ':bookcars-helper': path.resolve(__dirname, '../packages/bookcars-helper'),
+        ':bookcars-helper': path.resolve(__dirname, '../packages/bookcars-helper/index.ts'),
         ':disable-react-devtools': path.resolve(__dirname, '../packages/disable-react-devtools'),
       },
     },

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -23,7 +23,7 @@
     "paths": {
       "@/*": ["./src/*"],
       ":bookcars-types": ["../packages/bookcars-types"],
-      ":bookcars-helper": ["../packages/bookcars-helper"],
+      ":bookcars-helper": ["../packages/bookcars-helper/index.ts"],
       ":disable-react-devtools": ["../packages/disable-react-devtools"]
     },
   },

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -13,7 +13,7 @@ export default ({ mode }: { mode: string }) => {
       alias: {
         '@': path.resolve(__dirname, './src'),
         ':bookcars-types': path.resolve(__dirname, '../packages/bookcars-types'),
-        ':bookcars-helper': path.resolve(__dirname, '../packages/bookcars-helper'),
+        ':bookcars-helper': path.resolve(__dirname, '../packages/bookcars-helper/index.ts'),
         ':disable-react-devtools': path.resolve(__dirname, '../packages/disable-react-devtools'),
       },
     },

--- a/mobile/babel.config.js
+++ b/mobile/babel.config.js
@@ -20,7 +20,7 @@ module.exports = function (api) {
           "root": ['./'],
           "alias": {
             ":bookcars-types": "../packages/bookcars-types",
-            ":bookcars-helper": "../packages/bookcars-helper"
+            ":bookcars-helper": "../packages/bookcars-helper/index.ts"
           }
         }
       ],

--- a/mobile/tsconfig.json
+++ b/mobile/tsconfig.json
@@ -10,7 +10,7 @@
     "paths": {
       "@/*": ["./*"],
       ":bookcars-types": ["../packages/bookcars-types"],
-      ":bookcars-helper": ["../packages/bookcars-helper"]
+      ":bookcars-helper": ["../packages/bookcars-helper/index.ts"]
     }
   },
   "references": [


### PR DESCRIPTION
## Summary
- reference the helper `index.ts` file explicitly for React builds

## Testing
- `npm test` *(fails: rimraf not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b7d36caa48333954df97ed170242c