### PR TITLE
feat(frontend): add Tunisia car rental price guide page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -31,6 +31,7 @@ const NoMatch = lazy(() => import('@/pages/NoMatch'))
 const Locations = lazy(() => import('@/pages/Locations'))
 const Suppliers = lazy(() => import('@/pages/Suppliers'))
 const LocationATunis = lazy(() => import('@/pages/LocationATunis'))
+const LocationVoitureTunisiePrixDinars = lazy(() => import('@/pages/LocationVoitureTunisiePrixDinars'))
 const Review = lazy(() => import('@/pages/Review'))
 
 const App = () => (
@@ -61,6 +62,7 @@ const App = () => (
             <Route path="/suppliers" element={<Suppliers />} />
             <Route path="/review" element={<Review />} />
             <Route path="/location-voiture-pas-cher-a-tunis" element={<LocationATunis />} />
+            <Route path="/location-voiture-tunisie-prix-dinars" element={<LocationVoitureTunisiePrixDinars />} />
 
             <Route path="*" element={<NoMatch />} />
           </Routes>

--- a/frontend/src/pages/LocationVoitureTunisiePrixDinars.tsx
+++ b/frontend/src/pages/LocationVoitureTunisiePrixDinars.tsx
@@ -115,7 +115,7 @@ const LocationVoitureTunisiePrixDinars = () => {
         acceptedAnswer: {
           '@type': 'Answer',
           text:
-            'Préparez une caution de 800\u20131200 TND selon le modèle. Optez pour des offres avec assurance complète ou options réduisant le dépôt.'
+            'Préparez une caution de 800\u20132000 TND selon le modèle. Optez pour des offres avec assurance complète ou options réduisant le dépôt.'
         }
       }
     ]
@@ -153,21 +153,21 @@ const LocationVoitureTunisiePrixDinars = () => {
         '@type': 'OfferCatalog',
         name: 'Haute saison (juil–août)',
         itemListElement: [
-          { '@type': 'Offer', name: 'Kia Picanto', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '75', priceCurrency: 'TND' } },
-          { '@type': 'Offer', name: 'Hyundai i10', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '85', priceCurrency: 'TND' } },
-          { '@type': 'Offer', name: 'Suzuki Swift', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '90', priceCurrency: 'TND' } },
-          { '@type': 'Offer', name: 'Dacia Sandero', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '95', priceCurrency: 'TND' } },
-          { '@type': 'Offer', name: 'Skoda Fabia', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '95', priceCurrency: 'TND' } },
-          { '@type': 'Offer', name: 'Peugeot 208', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '100', priceCurrency: 'TND' } },
-          { '@type': 'Offer', name: 'Renault Clio 5', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '105', priceCurrency: 'TND' } },
-          { '@type': 'Offer', name: 'Volkswagen Polo', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '110', priceCurrency: 'TND' } },
-          { '@type': 'Offer', name: 'Volkswagen Virtus', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '115', priceCurrency: 'TND' } },
-          { '@type': 'Offer', name: 'Kia Rio', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '110', priceCurrency: 'TND' } },
-          { '@type': 'Offer', name: 'Hyundai i20', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '110', priceCurrency: 'TND' } },
-          { '@type': 'Offer', name: 'Mahindra KUV100', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '105', priceCurrency: 'TND' } },
-          { '@type': 'Offer', name: 'Mahindra XUV300', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '120', priceCurrency: 'TND' } },
-          { '@type': 'Offer', name: 'BYD F3', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '110', priceCurrency: 'TND' } },
-          { '@type': 'Offer', name: 'Chery Tiggo 3x', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '115', priceCurrency: 'TND' } }
+          { '@type': 'Offer', name: 'Kia Picanto', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '110', priceCurrency: 'TND' } },
+          { '@type': 'Offer', name: 'Hyundai i10', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '120', priceCurrency: 'TND' } },
+          { '@type': 'Offer', name: 'Suzuki Swift', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '130', priceCurrency: 'TND' } },
+          { '@type': 'Offer', name: 'Dacia Sandero', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '130', priceCurrency: 'TND' } },
+          { '@type': 'Offer', name: 'Skoda Fabia', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '130', priceCurrency: 'TND' } },
+          { '@type': 'Offer', name: 'Peugeot 208', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '130', priceCurrency: 'TND' } },
+          { '@type': 'Offer', name: 'Renault Clio 5', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '140', priceCurrency: 'TND' } },
+          { '@type': 'Offer', name: 'Volkswagen Polo', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '140', priceCurrency: 'TND' } },
+          { '@type': 'Offer', name: 'Volkswagen Virtus', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '145', priceCurrency: 'TND' } },
+          { '@type': 'Offer', name: 'Kia Rio', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '145', priceCurrency: 'TND' } },
+          { '@type': 'Offer', name: 'Hyundai i20', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '140', priceCurrency: 'TND' } },
+          { '@type': 'Offer', name: 'Mahindra KUV100', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '135', priceCurrency: 'TND' } },
+          { '@type': 'Offer', name: 'Mahindra XUV300', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '145', priceCurrency: 'TND' } },
+          { '@type': 'Offer', name: 'BYD F3', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '130', priceCurrency: 'TND' } },
+          { '@type': 'Offer', name: 'Chery Tiggo 3x', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '135', priceCurrency: 'TND' } }
         ]
       }
     ]
@@ -186,11 +186,11 @@ const LocationVoitureTunisiePrixDinars = () => {
             Location voiture Tunisie prix en dinars
           </Typography>
           <Typography variant="body1" sx={{ color: '#7f8c8d', mt: 3 }}>
-            Envie de parcourir la Tunisie en toute liberté ? Plany.tn compare pour vous les offres locales de location voiture pas chère Tunisie en TND, sans frais cachés.
+            Envie de parcourir la Tunisie en toute liberté ? Plany.tn compare pour vous les offres locales de location de voiture pas chère en Tunisie, en TND, sans frais cachés.
           </Typography>
-          <List sx={{ color: '#7f8c8d', mt: 2, mb: 5, maxWidth: 600, mx: 'auto' }}>
+          <List sx={{ color: '#7f8c8d', mt: 2, mb: 5, mx: 'auto' }}>
             <ListItem>Tarifs transparents en dinars tunisiens</ListItem>
-            <ListItem>Disponibilité à l’aéroport Tunis Carthage ou en centre-ville</ListItem>
+            <ListItem>Disponibilité à l’aéroport de Tunis-Carthage ou en centre-ville</ListItem>
             <ListItem>Comparateur local avec caution et assurance visibles</ListItem>
           </List>
           <Box sx={{ mt: 5 }}>
@@ -209,7 +209,7 @@ const LocationVoitureTunisiePrixDinars = () => {
             Variation des prix selon la saison
           </Typography>
           <Typography variant="body1" sx={{ color: '#7f8c8d', mt: 2 }}>
-            Les prix location voiture Tunisie hiver débutent à ~56 TND/j, tandis que la location voiture juillet août Tunisie voit la demande grimper. Réserver tôt permet de profiter des meilleurs tarifs.
+            Les prix de location de voiture en Tunisie en hiver débutent à ~56 TND/j, tandis qu’en juillet–août la demande grimpe. Réserver tôt permet de profiter des meilleurs tarifs.
           </Typography>
         </Box>
 
@@ -229,78 +229,78 @@ const LocationVoitureTunisiePrixDinars = () => {
               <TableBody>
                 <TableRow>
                   <TableCell>Kia Picanto (mini)</TableCell>
-                  <TableCell>~56 TND/j</TableCell>
-                  <TableCell>~75 TND/j</TableCell>
+                  <TableCell>~60 TND/j</TableCell>
+                  <TableCell>~110 TND/j</TableCell>
                 </TableRow>
                 <TableRow>
                   <TableCell>Hyundai i10 (éco)</TableCell>
-                  <TableCell>~65 TND/j</TableCell>
-                  <TableCell>~85 TND/j</TableCell>
+                  <TableCell>~69 TND/j</TableCell>
+                  <TableCell>~110 TND/j</TableCell>
                 </TableRow>
                 <TableRow>
                   <TableCell>Suzuki Swift (compacte)</TableCell>
                   <TableCell>~80 TND/j</TableCell>
-                  <TableCell>~90 TND/j</TableCell>
+                  <TableCell>~120 TND/j</TableCell>
                 </TableRow>
                 <TableRow>
                   <TableCell>Dacia Sandero (compacte)</TableCell>
                   <TableCell>~75 TND/j</TableCell>
-                  <TableCell>~95 TND/j</TableCell>
+                  <TableCell>~120 TND/j</TableCell>
                 </TableRow>
                 <TableRow>
                   <TableCell>Skoda Fabia (compacte)</TableCell>
-                  <TableCell>~75 TND/j</TableCell>
-                  <TableCell>~95 TND/j</TableCell>
+                  <TableCell>~80 TND/j</TableCell>
+                  <TableCell>~130 TND/j</TableCell>
                 </TableRow>
                 <TableRow>
                   <TableCell>Peugeot 208 (compacte)</TableCell>
-                  <TableCell>~80 TND/j</TableCell>
-                  <TableCell>~100 TND/j</TableCell>
+                  <TableCell>~90 TND/j</TableCell>
+                  <TableCell>~135 TND/j</TableCell>
                 </TableRow>
                 <TableRow>
                   <TableCell>Renault Clio 5 (compacte)</TableCell>
-                  <TableCell>~85 TND/j</TableCell>
-                  <TableCell>~105 TND/j</TableCell>
+                  <TableCell>~90 TND/j</TableCell>
+                  <TableCell>~140 TND/j</TableCell>
                 </TableRow>
                 <TableRow>
                   <TableCell>Volkswagen Polo (compacte)</TableCell>
                   <TableCell>~85 TND/j</TableCell>
-                  <TableCell>~110 TND/j</TableCell>
+                  <TableCell>~150 TND/j</TableCell>
                 </TableRow>
                 <TableRow>
                   <TableCell>Volkswagen Virtus (berline)</TableCell>
-                  <TableCell>~90 TND/j</TableCell>
-                  <TableCell>~115 TND/j</TableCell>
+                  <TableCell>~100 TND/j</TableCell>
+                  <TableCell>~150 TND/j</TableCell>
                 </TableRow>
                 <TableRow>
                   <TableCell>Kia Rio (berline)</TableCell>
-                  <TableCell>~85 TND/j</TableCell>
-                  <TableCell>~110 TND/j</TableCell>
+                  <TableCell>~99 TND/j</TableCell>
+                  <TableCell>~145 TND/j</TableCell>
                 </TableRow>
                 <TableRow>
                   <TableCell>Hyundai i20 (compacte+)</TableCell>
                   <TableCell>~85 TND/j</TableCell>
-                  <TableCell>~110 TND/j</TableCell>
+                  <TableCell>~140 TND/j</TableCell>
                 </TableRow>
                 <TableRow>
                   <TableCell>Mahindra KUV100 (SUV urbain)</TableCell>
-                  <TableCell>~80 TND/j</TableCell>
-                  <TableCell>~105 TND/j</TableCell>
+                  <TableCell>~90 TND/j</TableCell>
+                  <TableCell>~130 TND/j</TableCell>
                 </TableRow>
                 <TableRow>
                   <TableCell>Mahindra XUV300 (SUV)</TableCell>
-                  <TableCell>~90 TND/j</TableCell>
-                  <TableCell>~120 TND/j</TableCell>
+                  <TableCell>~100 TND/j</TableCell>
+                  <TableCell>~140 TND/j</TableCell>
                 </TableRow>
                 <TableRow>
                   <TableCell>BYD F3 (berline)</TableCell>
-                  <TableCell>~85 TND/j</TableCell>
-                  <TableCell>~110 TND/j</TableCell>
+                  <TableCell>~100 TND/j</TableCell>
+                  <TableCell>~140 TND/j</TableCell>
                 </TableRow>
                 <TableRow>
                   <TableCell>Chery Tiggo 3x (SUV urbain)</TableCell>
                   <TableCell>~85 TND/j</TableCell>
-                  <TableCell>~115 TND/j</TableCell>
+                  <TableCell>~130TND/j</TableCell>
                 </TableRow>
               </TableBody>
             </Table>
@@ -316,10 +316,10 @@ const LocationVoitureTunisiePrixDinars = () => {
               <Paper elevation={3} sx={{ p: 3, textAlign: 'center', height: '100%' }}>
                 <AltRouteIcon sx={{ fontSize: 40, color: 'primary.main' }} />
                 <Typography variant="h6" component="h3" sx={{ fontWeight: 'bold', mt: 1 }}>
-                  Kilométrage illimité
+                  Kilométrage illimité (selon l&apos;agence)
                 </Typography>
                 <Typography variant="body2" sx={{ color: '#7f8c8d', mt: 1 }}>
-                  De nombreuses offres incluent le kilométrage illimité location Tunisie pour explorer le pays sans contrainte.
+                  De nombreuses offres incluent le kilométrage illimité pour explorer le pays sans contrainte.
                 </Typography>
               </Paper>
             </Grid>
@@ -330,7 +330,7 @@ const LocationVoitureTunisiePrixDinars = () => {
                   Annulation flexible
                 </Typography>
                 <Typography variant="body2" sx={{ color: '#7f8c8d', mt: 1 }}>
-                  Souvent gratuite jusqu\u2019à J-2 selon l\u2019offre, vous gardez le contrôle de votre réservation.
+                  Souvent gratuite jusqu’à J−7 selon l’offre, vous gardez le contrôle de votre réservation.
                 </Typography>
               </Paper>
             </Grid>
@@ -341,7 +341,7 @@ const LocationVoitureTunisiePrixDinars = () => {
                   Caution transparente
                 </Typography>
                 <Typography variant="body2" sx={{ color: '#7f8c8d', mt: 1 }}>
-                  Les dépôts de garantie et l\u2019assurance location voiture Tunisie sont clairement indiqués pour comparer facilement.
+                  Les dépôts de garantie et l’assurance pour la location de voiture en Tunisie sont clairement indiqués pour comparer facilement.
                 </Typography>
               </Paper>
             </Grid>
@@ -352,7 +352,7 @@ const LocationVoitureTunisiePrixDinars = () => {
                   Large choix de véhicules
                 </Typography>
                 <Typography variant="body2" sx={{ color: '#7f8c8d', mt: 1 }}>
-                  Boîte manuelle ou voiture automatique Tunisie location, citadines, SUV ou minivans : filtrez et choisissez facilement.
+                  Boîte manuelle ou automatique, citadines, SUV ou minivans : filtrez et choisissez facilement.
                 </Typography>
               </Paper>
             </Grid>
@@ -403,7 +403,7 @@ const LocationVoitureTunisiePrixDinars = () => {
             </AccordionSummary>
             <AccordionDetails>
               <Typography variant="body1" sx={{ color: '#7f8c8d' }}>
-                En haute saison, comptez généralement 100–120 TND/j pour une citadine économique réservée à l’avance.
+                En haute saison, comptez généralement 120–150 TND/j pour une citadine économique réservée à l’avance.
               </Typography>
             </AccordionDetails>
           </Accordion>
@@ -439,7 +439,7 @@ const LocationVoitureTunisiePrixDinars = () => {
             </AccordionSummary>
             <AccordionDetails>
               <Typography variant="body1" sx={{ color: '#7f8c8d' }}>
-                La plupart des offres offrent une annulation gratuite jusqu’48 h avant la prise en charge.
+                La plupart des offres proposent une annulation gratuite jusqu’à 7 jours avant la prise en charge.
               </Typography>
             </AccordionDetails>
           </Accordion>
@@ -451,7 +451,7 @@ const LocationVoitureTunisiePrixDinars = () => {
             </AccordionSummary>
             <AccordionDetails>
               <Typography variant="body1" sx={{ color: '#7f8c8d' }}>
-                Préparez une caution de 800–1200 TND selon le modèle. Choisissez des offres avec assurance complète ou options réduisant le dépôt.
+                Préparez une caution de 800–2000 TND selon le modèle.
               </Typography>
             </AccordionDetails>
           </Accordion>
@@ -462,8 +462,8 @@ const LocationVoitureTunisiePrixDinars = () => {
             Conclusion
           </Typography>
           <Typography variant="body1" sx={{ color: '#7f8c8d', mt: 2 }}>
-            Location voiture Tunisie prix en dinars : retenez que les tarifs varient selon la saison, mais Plany.tn garantit transparence et avantages exclusifs.
-            Comparez les offres et r\u00E9servez sur Plany.tn.
+            Location voiture Tunisie prix en dinars : retenez que les tarifs varient selon la saison, mais Plany.tn garantit la transparence et des avantages exclusifs.
+            Comparez les offres et réservez sur Plany.tn.
           </Typography>
         </Box>
 

--- a/frontend/src/pages/LocationVoitureTunisiePrixDinars.tsx
+++ b/frontend/src/pages/LocationVoitureTunisiePrixDinars.tsx
@@ -1,0 +1,362 @@
+import React from 'react'
+import { Container, Typography, Box, Table, TableBody, TableCell, TableHead, TableRow, List, ListItem } from '@mui/material'
+import Layout from '@/components/Layout'
+import Footer from '@/components/Footer'
+import '@/assets/css/home.css'
+import SearchForm from '@/components/SearchForm'
+import Seo from '@/components/Seo'
+import { buildDescription } from '@/common/seo'
+
+const LocationVoitureTunisiePrixDinars = () => {
+  const description = buildDescription(
+    'Location voiture Tunisie prix en dinars : hiver vs été dès 56 TND/j, kilométrage illimité, annulation flexible. Comparez et réservez sur Plany.tn'
+  )
+
+  const articleJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    '@id': 'https://plany.tn/location-voiture-tunisie-prix-dinars#article',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://plany.tn/location-voiture-tunisie-prix-dinars'
+    },
+    headline: 'Location voiture en Tunisie : prix en dinars (hiver vs haute saison)',
+    description:
+      'Comparez les prix de location de voiture en Tunisie en TND : hiver (déc–fév) vs haute saison (juil–août). Modèles populaires, conseils & avantages Plany.tn.',
+    image: ['https://plany.tn/static/og/location-voiture-tunisie.jpg'],
+    author: {
+      '@type': 'Organization',
+      name: 'Plany.tn',
+      url: 'https://plany.tn'
+    },
+    publisher: {
+      '@type': 'Organization',
+      name: 'Plany.tn',
+      url: 'https://plany.tn',
+      logo: {
+        '@type': 'ImageObject',
+        url: 'https://plany.tn/static/logo/plany-logo-512.png',
+        width: 512,
+        height: 512
+      }
+    },
+    datePublished: '2025-08-21',
+    dateModified: '2025-08-21'
+  }
+
+  const faqJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: [
+      {
+        '@type': 'Question',
+        name: 'Quel est le prix moyen d\u2019une location en été en Tunisie ?',
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text:
+            'En haute saison (juil–août), comptez généralement ~100–120 TND/j pour une citadine économique réservée à l\u2019avance, avec des pics possibles pour les modèles très demandés.'
+        }
+      },
+      {
+        '@type': 'Question',
+        name: 'Faut-il un permis international pour louer en Tunisie ?',
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text:
+            'Pour un séjour touristique court, un permis national lisible en caractères latins suffit généralement. Le permis international n\u2019est pas systématiquement exigé.'
+        }
+      },
+      {
+        '@type': 'Question',
+        name: 'Peut-on louer une voiture automatique à Tunis (aéroport Tunis-Carthage) ?',
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text:
+            'Oui, de nombreuses agences proposent des voitures automatiques à Tunis et à l\u2019aéroport TUN. Il est conseillé de réserver tôt en été pour garantir la disponibilité.'
+        }
+      },
+      {
+        '@type': 'Question',
+        name: 'Quelle est la politique d\u2019annulation avec Plany.tn ?',
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text:
+            'La majorité des offres affichent une annulation flexible, souvent gratuite jusqu\u2019à 48 h avant la prise en charge. Les conditions exactes figurent sur chaque fiche véhicule.'
+        }
+      }
+    ]
+  }
+
+  const offerCatalogJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'OfferCatalog',
+    '@id': 'https://plany.tn/location-voiture-tunisie-prix-dinars#catalog',
+    name: 'Fourchettes de prix location voiture en Tunisie (TND/jour)',
+    url: 'https://plany.tn/location-voiture-tunisie-prix-dinars',
+    itemListElement: [
+      {
+        '@type': 'OfferCatalog',
+        name: 'Hiver (déc–fév)',
+        itemListElement: [
+          { '@type': 'Offer', name: 'Kia Picanto', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '56', priceCurrency: 'TND' } },
+          { '@type': 'Offer', name: 'Hyundai i10', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '65', priceCurrency: 'TND' } },
+          { '@type': 'Offer', name: 'Suzuki Swift', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '80', priceCurrency: 'TND' } },
+          { '@type': 'Offer', name: 'Dacia Sandero', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '75', priceCurrency: 'TND' } },
+          { '@type': 'Offer', name: 'Skoda Fabia', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '75', priceCurrency: 'TND' } },
+          { '@type': 'Offer', name: 'Peugeot 208', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '80', priceCurrency: 'TND' } },
+          { '@type': 'Offer', name: 'Renault Clio 5', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '85', priceCurrency: 'TND' } },
+          { '@type': 'Offer', name: 'Volkswagen Polo', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '85', priceCurrency: 'TND' } },
+          { '@type': 'Offer', name: 'Volkswagen Virtus', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '90', priceCurrency: 'TND' } },
+          { '@type': 'Offer', name: 'Kia Rio', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '85', priceCurrency: 'TND' } },
+          { '@type': 'Offer', name: 'Hyundai i20', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '85', priceCurrency: 'TND' } },
+          { '@type': 'Offer', name: 'Mahindra KUV100', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '80', priceCurrency: 'TND' } },
+          { '@type': 'Offer', name: 'Mahindra XUV300', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '90', priceCurrency: 'TND' } },
+          { '@type': 'Offer', name: 'BYD F3', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '85', priceCurrency: 'TND' } },
+          { '@type': 'Offer', name: 'Chery Tiggo 3x', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '85', priceCurrency: 'TND' } }
+        ]
+      },
+      {
+        '@type': 'OfferCatalog',
+        name: 'Haute saison (juil–août)',
+        itemListElement: [
+          { '@type': 'Offer', name: 'Kia Picanto', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '75', priceCurrency: 'TND' } },
+          { '@type': 'Offer', name: 'Hyundai i10', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '85', priceCurrency: 'TND' } },
+          { '@type': 'Offer', name: 'Suzuki Swift', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '90', priceCurrency: 'TND' } },
+          { '@type': 'Offer', name: 'Dacia Sandero', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '95', priceCurrency: 'TND' } },
+          { '@type': 'Offer', name: 'Skoda Fabia', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '95', priceCurrency: 'TND' } },
+          { '@type': 'Offer', name: 'Peugeot 208', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '100', priceCurrency: 'TND' } },
+          { '@type': 'Offer', name: 'Renault Clio 5', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '105', priceCurrency: 'TND' } },
+          { '@type': 'Offer', name: 'Volkswagen Polo', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '110', priceCurrency: 'TND' } },
+          { '@type': 'Offer', name: 'Volkswagen Virtus', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '115', priceCurrency: 'TND' } },
+          { '@type': 'Offer', name: 'Kia Rio', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '110', priceCurrency: 'TND' } },
+          { '@type': 'Offer', name: 'Hyundai i20', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '110', priceCurrency: 'TND' } },
+          { '@type': 'Offer', name: 'Mahindra KUV100', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '105', priceCurrency: 'TND' } },
+          { '@type': 'Offer', name: 'Mahindra XUV300', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '120', priceCurrency: 'TND' } },
+          { '@type': 'Offer', name: 'BYD F3', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '110', priceCurrency: 'TND' } },
+          { '@type': 'Offer', name: 'Chery Tiggo 3x', priceCurrency: 'TND', priceSpecification: { '@type': 'PriceSpecification', price: '115', priceCurrency: 'TND' } }
+        ]
+      }
+    ]
+  }
+
+  return (
+    <Layout strict={false}>
+      <Seo
+        title="Location voiture Tunisie : prix en dinars | Plany.tn"
+        description={description}
+        canonical="https://plany.tn/location-voiture-tunisie-prix-dinars"
+      />
+      <Container maxWidth="lg">
+        <Box sx={{ textAlign: 'center', mt: 8, mb: 8 }}>
+          <Typography variant="h2" component="h1" gutterBottom sx={{ fontWeight: 'bold', color: '#2c3e50' }}>
+            Location voiture Tunisie prix en dinars
+          </Typography>
+          <Typography variant="body1" sx={{ color: '#7f8c8d', mt: 3, mb: 5 }}>
+            Envie de parcourir la Tunisie en toute liberté ? Plany.tn compare pour vous les offres locales de location voiture pas chère Tunisie en TND, sans frais cachés, que ce soit pour une location voiture aéroport Tunis Carthage ou au centre-ville.
+          </Typography>
+          <div className="home custom-searsh">
+            <div className="home-search">
+              <SearchForm />
+            </div>
+          </div>
+        </Box>
+
+        <Box sx={{ mt: 8 }}>
+          <Typography variant="h4" component="h2" gutterBottom sx={{ fontWeight: 'bold', color: '#2c3e50' }}>
+            Variation des prix selon la saison
+          </Typography>
+          <Typography variant="body1" sx={{ color: '#7f8c8d', mt: 2 }}>
+            Les prix location voiture Tunisie hiver débutent à ~56 TND/j, tandis que la location voiture juillet août Tunisie voit la demande grimper. Réserver tôt permet de profiter des meilleurs tarifs.
+          </Typography>
+        </Box>
+
+        <Box sx={{ mt: 6 }}>
+          <Typography variant="h4" component="h2" gutterBottom sx={{ fontWeight: 'bold', color: '#2c3e50' }}>
+            Prix indicatifs par modèle (TND/jour)
+          </Typography>
+          <Table>
+            <TableHead>
+              <TableRow>
+                <TableCell>Modèle (catégorie)</TableCell>
+                <TableCell>Hiver (déc\u2013fév)</TableCell>
+                <TableCell>Haute saison (juil\u2013août)</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              <TableRow>
+                <TableCell>Kia Picanto (mini)</TableCell>
+                <TableCell>~56 TND/j</TableCell>
+                <TableCell>~75 TND/j</TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell>Hyundai i10 (éco)</TableCell>
+                <TableCell>~65 TND/j</TableCell>
+                <TableCell>~85 TND/j</TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell>Suzuki Swift (compacte)</TableCell>
+                <TableCell>~80 TND/j</TableCell>
+                <TableCell>~90 TND/j</TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell>Dacia Sandero (compacte)</TableCell>
+                <TableCell>~75 TND/j</TableCell>
+                <TableCell>~95 TND/j</TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell>Skoda Fabia (compacte)</TableCell>
+                <TableCell>~75 TND/j</TableCell>
+                <TableCell>~95 TND/j</TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell>Peugeot 208 (compacte)</TableCell>
+                <TableCell>~80 TND/j</TableCell>
+                <TableCell>~100 TND/j</TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell>Renault Clio 5 (compacte)</TableCell>
+                <TableCell>~85 TND/j</TableCell>
+                <TableCell>~105 TND/j</TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell>Volkswagen Polo (compacte)</TableCell>
+                <TableCell>~85 TND/j</TableCell>
+                <TableCell>~110 TND/j</TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell>Volkswagen Virtus (berline)</TableCell>
+                <TableCell>~90 TND/j</TableCell>
+                <TableCell>~115 TND/j</TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell>Kia Rio (berline)</TableCell>
+                <TableCell>~85 TND/j</TableCell>
+                <TableCell>~110 TND/j</TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell>Hyundai i20 (compacte+)</TableCell>
+                <TableCell>~85 TND/j</TableCell>
+                <TableCell>~110 TND/j</TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell>Mahindra KUV100 (SUV urbain)</TableCell>
+                <TableCell>~80 TND/j</TableCell>
+                <TableCell>~105 TND/j</TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell>Mahindra XUV300 (SUV)</TableCell>
+                <TableCell>~90 TND/j</TableCell>
+                <TableCell>~120 TND/j</TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell>BYD F3 (berline)</TableCell>
+                <TableCell>~85 TND/j</TableCell>
+                <TableCell>~110 TND/j</TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell>Chery Tiggo 3x (SUV urbain)</TableCell>
+                <TableCell>~85 TND/j</TableCell>
+                <TableCell>~115 TND/j</TableCell>
+              </TableRow>
+            </TableBody>
+          </Table>
+        </Box>
+
+        <Box sx={{ mt: 8 }}>
+          <Typography variant="h4" component="h2" gutterBottom sx={{ fontWeight: 'bold', color: '#2c3e50' }}>
+            Les avantages de Plany.tn
+          </Typography>
+          <Typography variant="h5" component="h3" sx={{ fontWeight: 'bold', mt: 4 }}>
+            Kilométrage illimité
+          </Typography>
+          <Typography variant="body1" sx={{ color: '#7f8c8d', mt: 1 }}>
+            De nombreuses offres incluent le kilométrage illimité location Tunisie pour explorer le pays sans contrainte.
+          </Typography>
+          <Typography variant="h5" component="h3" sx={{ fontWeight: 'bold', mt: 4 }}>
+            Annulation flexible
+          </Typography>
+          <Typography variant="body1" sx={{ color: '#7f8c8d', mt: 1 }}>
+            Souvent gratuite jusqu\u2019à J-2 selon l\u2019offre, vous gardez le contrôle de votre réservation.
+          </Typography>
+          <Typography variant="h5" component="h3" sx={{ fontWeight: 'bold', mt: 4 }}>
+            Caution transparente
+          </Typography>
+          <Typography variant="body1" sx={{ color: '#7f8c8d', mt: 1 }}>
+            Les dépôts de garantie sont clairement indiqués. La caution location voiture Tunisie et l\u2019assurance location voiture Tunisie sont visibles pour comparer et choisir une caution faible.
+          </Typography>
+          <Typography variant="h5" component="h3" sx={{ fontWeight: 'bold', mt: 4 }}>
+            Large choix de véhicules
+          </Typography>
+          <Typography variant="body1" sx={{ color: '#7f8c8d', mt: 1 }}>
+            Boîte manuelle ou voiture automatique Tunisie location, citadines, SUV ou minivans pour votre location voiture touristique Tunisie : Plany.tn propose un catalogue complet avec filtres pratiques.
+          </Typography>
+        </Box>
+
+        <Box sx={{ mt: 8 }}>
+          <Typography variant="h4" component="h2" gutterBottom sx={{ fontWeight: 'bold', color: '#2c3e50' }}>
+            Conseils pour économiser
+          </Typography>
+          <List sx={{ color: '#7f8c8d', mt: 2 }}>
+            <ListItem>Réservez tôt, surtout pour juillet et août</ListItem>
+            <ListItem>Comparez les prix entre l\u2019aéroport et le centre-ville</ListItem>
+            <ListItem>Évitez les réservations de dernière minute</ListItem>
+            <ListItem>Plus la durée est longue, plus le prix par jour baisse</ListItem>
+          </List>
+        </Box>
+
+        <Box sx={{ mt: 8 }}>
+          <Typography variant="h4" component="h2" gutterBottom sx={{ fontWeight: 'bold', color: '#2c3e50' }}>
+            FAQ
+          </Typography>
+          <Typography variant="h5" component="h3" sx={{ fontWeight: 'bold', mt: 4 }}>
+            Quel est le prix moyen d\u2019une location en été en Tunisie ?
+          </Typography>
+          <Typography variant="body1" sx={{ color: '#7f8c8d', mt: 1 }}>
+            En haute saison, comptez généralement 100\u2013120 TND/j pour une citadine économique réservée à l\u2019avance.
+          </Typography>
+          <Typography variant="h5" component="h3" sx={{ fontWeight: 'bold', mt: 4 }}>
+            Faut-il un permis international pour louer en Tunisie ?
+          </Typography>
+          <Typography variant="body1" sx={{ color: '#7f8c8d', mt: 1 }}>
+            Un permis national lisible suffit pour un court séjour touristique. Le permis international n\u2019est pas toujours exigé.
+          </Typography>
+          <Typography variant="h5" component="h3" sx={{ fontWeight: 'bold', mt: 4 }}>
+            Peut-on louer une voiture automatique à Tunis (aéroport Tunis-Carthage) ?
+          </Typography>
+          <Typography variant="body1" sx={{ color: '#7f8c8d', mt: 1 }}>
+            Oui, de nombreuses agences proposent des voitures automatiques à Tunis et à l\u2019aéroport Tunis-Carthage.
+          </Typography>
+          <Typography variant="h5" component="h3" sx={{ fontWeight: 'bold', mt: 4 }}>
+            Quelle est la politique d\u2019annulation avec Plany.tn ?
+          </Typography>
+          <Typography variant="body1" sx={{ color: '#7f8c8d', mt: 1 }}>
+            La plupart des offres offrent une annulation gratuite jusqu\u201948 h avant la prise en charge.
+          </Typography>
+          <Typography variant="h5" component="h3" sx={{ fontWeight: 'bold', mt: 4 }}>
+            Quelle caution prévoir et comment la réduire ?
+          </Typography>
+          <Typography variant="body1" sx={{ color: '#7f8c8d', mt: 1 }}>
+            Préparez une caution de 800\u20131200 TND selon le modèle. Choisissez des offres avec assurance complète ou options r\u00E9duisant le d\u00E9p\u00F4t.
+          </Typography>
+        </Box>
+
+        <Box sx={{ mt: 8, mb: 8 }}>
+          <Typography variant="h4" component="h2" gutterBottom sx={{ fontWeight: 'bold', color: '#2c3e50' }}>
+            Conclusion
+          </Typography>
+          <Typography variant="body1" sx={{ color: '#7f8c8d', mt: 2 }}>
+            Location voiture Tunisie prix en dinars : retenez que les tarifs varient selon la saison, mais Plany.tn garantit transparence et avantages exclusifs.
+            Comparez les offres et r\u00E9servez sur Plany.tn.
+          </Typography>
+        </Box>
+
+      </Container>
+      <Footer />
+      <script type="application/ld+json">{JSON.stringify(articleJsonLd)}</script>
+      <script type="application/ld+json">{JSON.stringify(faqJsonLd)}</script>
+      <script type="application/ld+json">{JSON.stringify(offerCatalogJsonLd)}</script>
+    </Layout>
+  )
+}
+
+export default LocationVoitureTunisiePrixDinars

--- a/frontend/src/pages/LocationVoitureTunisiePrixDinars.tsx
+++ b/frontend/src/pages/LocationVoitureTunisiePrixDinars.tsx
@@ -1,5 +1,30 @@
 import React from 'react'
-import { Container, Typography, Box, Table, TableBody, TableCell, TableHead, TableRow, List, ListItem } from '@mui/material'
+import {
+  Container,
+  Typography,
+  Box,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  List,
+  ListItem,
+  TableContainer,
+  Paper,
+  Grid,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+  ListItemIcon,
+  ListItemText
+} from '@mui/material'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+import AltRouteIcon from '@mui/icons-material/AltRoute'
+import CachedIcon from '@mui/icons-material/Cached'
+import SecurityIcon from '@mui/icons-material/Security'
+import DirectionsCarIcon from '@mui/icons-material/DirectionsCar'
+import CheckCircleIcon from '@mui/icons-material/CheckCircle'
 import Layout from '@/components/Layout'
 import Footer from '@/components/Footer'
 import '@/assets/css/home.css'
@@ -83,6 +108,15 @@ const LocationVoitureTunisiePrixDinars = () => {
           text:
             'La majorité des offres affichent une annulation flexible, souvent gratuite jusqu\u2019à 48 h avant la prise en charge. Les conditions exactes figurent sur chaque fiche véhicule.'
         }
+      },
+      {
+        '@type': 'Question',
+        name: 'Quelle caution prévoir et comment la réduire ?',
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text:
+            'Préparez une caution de 800\u20131200 TND selon le modèle. Optez pour des offres avec assurance complète ou options réduisant le dépôt.'
+        }
       }
     ]
   }
@@ -151,14 +185,23 @@ const LocationVoitureTunisiePrixDinars = () => {
           <Typography variant="h2" component="h1" gutterBottom sx={{ fontWeight: 'bold', color: '#2c3e50' }}>
             Location voiture Tunisie prix en dinars
           </Typography>
-          <Typography variant="body1" sx={{ color: '#7f8c8d', mt: 3, mb: 5 }}>
-            Envie de parcourir la Tunisie en toute liberté ? Plany.tn compare pour vous les offres locales de location voiture pas chère Tunisie en TND, sans frais cachés, que ce soit pour une location voiture aéroport Tunis Carthage ou au centre-ville.
+          <Typography variant="body1" sx={{ color: '#7f8c8d', mt: 3 }}>
+            Envie de parcourir la Tunisie en toute liberté ? Plany.tn compare pour vous les offres locales de location voiture pas chère Tunisie en TND, sans frais cachés.
           </Typography>
-          <div className="home custom-searsh">
-            <div className="home-search">
-              <SearchForm />
-            </div>
-          </div>
+          <List sx={{ color: '#7f8c8d', mt: 2, mb: 5, maxWidth: 600, mx: 'auto' }}>
+            <ListItem>Tarifs transparents en dinars tunisiens</ListItem>
+            <ListItem>Disponibilité à l’aéroport Tunis Carthage ou en centre-ville</ListItem>
+            <ListItem>Comparateur local avec caution et assurance visibles</ListItem>
+          </List>
+          <Box sx={{ mt: 5 }}>
+            <Paper elevation={3} sx={{ p: { xs: 2, md: 4 } }}>
+              <div className="home custom-searsh">
+                <div className="home-search">
+                  <SearchForm />
+                </div>
+              </div>
+            </Paper>
+          </Box>
         </Box>
 
         <Box sx={{ mt: 8 }}>
@@ -174,122 +217,146 @@ const LocationVoitureTunisiePrixDinars = () => {
           <Typography variant="h4" component="h2" gutterBottom sx={{ fontWeight: 'bold', color: '#2c3e50' }}>
             Prix indicatifs par modèle (TND/jour)
           </Typography>
-          <Table>
-            <TableHead>
-              <TableRow>
-                <TableCell>Modèle (catégorie)</TableCell>
-                <TableCell>Hiver (déc\u2013fév)</TableCell>
-                <TableCell>Haute saison (juil\u2013août)</TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              <TableRow>
-                <TableCell>Kia Picanto (mini)</TableCell>
-                <TableCell>~56 TND/j</TableCell>
-                <TableCell>~75 TND/j</TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell>Hyundai i10 (éco)</TableCell>
-                <TableCell>~65 TND/j</TableCell>
-                <TableCell>~85 TND/j</TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell>Suzuki Swift (compacte)</TableCell>
-                <TableCell>~80 TND/j</TableCell>
-                <TableCell>~90 TND/j</TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell>Dacia Sandero (compacte)</TableCell>
-                <TableCell>~75 TND/j</TableCell>
-                <TableCell>~95 TND/j</TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell>Skoda Fabia (compacte)</TableCell>
-                <TableCell>~75 TND/j</TableCell>
-                <TableCell>~95 TND/j</TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell>Peugeot 208 (compacte)</TableCell>
-                <TableCell>~80 TND/j</TableCell>
-                <TableCell>~100 TND/j</TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell>Renault Clio 5 (compacte)</TableCell>
-                <TableCell>~85 TND/j</TableCell>
-                <TableCell>~105 TND/j</TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell>Volkswagen Polo (compacte)</TableCell>
-                <TableCell>~85 TND/j</TableCell>
-                <TableCell>~110 TND/j</TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell>Volkswagen Virtus (berline)</TableCell>
-                <TableCell>~90 TND/j</TableCell>
-                <TableCell>~115 TND/j</TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell>Kia Rio (berline)</TableCell>
-                <TableCell>~85 TND/j</TableCell>
-                <TableCell>~110 TND/j</TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell>Hyundai i20 (compacte+)</TableCell>
-                <TableCell>~85 TND/j</TableCell>
-                <TableCell>~110 TND/j</TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell>Mahindra KUV100 (SUV urbain)</TableCell>
-                <TableCell>~80 TND/j</TableCell>
-                <TableCell>~105 TND/j</TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell>Mahindra XUV300 (SUV)</TableCell>
-                <TableCell>~90 TND/j</TableCell>
-                <TableCell>~120 TND/j</TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell>BYD F3 (berline)</TableCell>
-                <TableCell>~85 TND/j</TableCell>
-                <TableCell>~110 TND/j</TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell>Chery Tiggo 3x (SUV urbain)</TableCell>
-                <TableCell>~85 TND/j</TableCell>
-                <TableCell>~115 TND/j</TableCell>
-              </TableRow>
-            </TableBody>
-          </Table>
+          <TableContainer component={Paper} sx={{ mt: 2 }}>
+            <Table>
+              <TableHead>
+                <TableRow>
+                  <TableCell>Modèle (catégorie)</TableCell>
+                  <TableCell>Hiver (déc\u2013fév)</TableCell>
+                  <TableCell>Haute saison (juil\u2013août)</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                <TableRow>
+                  <TableCell>Kia Picanto (mini)</TableCell>
+                  <TableCell>~56 TND/j</TableCell>
+                  <TableCell>~75 TND/j</TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>Hyundai i10 (éco)</TableCell>
+                  <TableCell>~65 TND/j</TableCell>
+                  <TableCell>~85 TND/j</TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>Suzuki Swift (compacte)</TableCell>
+                  <TableCell>~80 TND/j</TableCell>
+                  <TableCell>~90 TND/j</TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>Dacia Sandero (compacte)</TableCell>
+                  <TableCell>~75 TND/j</TableCell>
+                  <TableCell>~95 TND/j</TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>Skoda Fabia (compacte)</TableCell>
+                  <TableCell>~75 TND/j</TableCell>
+                  <TableCell>~95 TND/j</TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>Peugeot 208 (compacte)</TableCell>
+                  <TableCell>~80 TND/j</TableCell>
+                  <TableCell>~100 TND/j</TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>Renault Clio 5 (compacte)</TableCell>
+                  <TableCell>~85 TND/j</TableCell>
+                  <TableCell>~105 TND/j</TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>Volkswagen Polo (compacte)</TableCell>
+                  <TableCell>~85 TND/j</TableCell>
+                  <TableCell>~110 TND/j</TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>Volkswagen Virtus (berline)</TableCell>
+                  <TableCell>~90 TND/j</TableCell>
+                  <TableCell>~115 TND/j</TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>Kia Rio (berline)</TableCell>
+                  <TableCell>~85 TND/j</TableCell>
+                  <TableCell>~110 TND/j</TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>Hyundai i20 (compacte+)</TableCell>
+                  <TableCell>~85 TND/j</TableCell>
+                  <TableCell>~110 TND/j</TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>Mahindra KUV100 (SUV urbain)</TableCell>
+                  <TableCell>~80 TND/j</TableCell>
+                  <TableCell>~105 TND/j</TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>Mahindra XUV300 (SUV)</TableCell>
+                  <TableCell>~90 TND/j</TableCell>
+                  <TableCell>~120 TND/j</TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>BYD F3 (berline)</TableCell>
+                  <TableCell>~85 TND/j</TableCell>
+                  <TableCell>~110 TND/j</TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>Chery Tiggo 3x (SUV urbain)</TableCell>
+                  <TableCell>~85 TND/j</TableCell>
+                  <TableCell>~115 TND/j</TableCell>
+                </TableRow>
+              </TableBody>
+            </Table>
+          </TableContainer>
         </Box>
 
         <Box sx={{ mt: 8 }}>
           <Typography variant="h4" component="h2" gutterBottom sx={{ fontWeight: 'bold', color: '#2c3e50' }}>
             Les avantages de Plany.tn
           </Typography>
-          <Typography variant="h5" component="h3" sx={{ fontWeight: 'bold', mt: 4 }}>
-            Kilométrage illimité
-          </Typography>
-          <Typography variant="body1" sx={{ color: '#7f8c8d', mt: 1 }}>
-            De nombreuses offres incluent le kilométrage illimité location Tunisie pour explorer le pays sans contrainte.
-          </Typography>
-          <Typography variant="h5" component="h3" sx={{ fontWeight: 'bold', mt: 4 }}>
-            Annulation flexible
-          </Typography>
-          <Typography variant="body1" sx={{ color: '#7f8c8d', mt: 1 }}>
-            Souvent gratuite jusqu\u2019à J-2 selon l\u2019offre, vous gardez le contrôle de votre réservation.
-          </Typography>
-          <Typography variant="h5" component="h3" sx={{ fontWeight: 'bold', mt: 4 }}>
-            Caution transparente
-          </Typography>
-          <Typography variant="body1" sx={{ color: '#7f8c8d', mt: 1 }}>
-            Les dépôts de garantie sont clairement indiqués. La caution location voiture Tunisie et l\u2019assurance location voiture Tunisie sont visibles pour comparer et choisir une caution faible.
-          </Typography>
-          <Typography variant="h5" component="h3" sx={{ fontWeight: 'bold', mt: 4 }}>
-            Large choix de véhicules
-          </Typography>
-          <Typography variant="body1" sx={{ color: '#7f8c8d', mt: 1 }}>
-            Boîte manuelle ou voiture automatique Tunisie location, citadines, SUV ou minivans pour votre location voiture touristique Tunisie : Plany.tn propose un catalogue complet avec filtres pratiques.
-          </Typography>
+          <Grid container spacing={4} sx={{ mt: 2 }}>
+            <Grid item xs={12} md={6} lg={3}>
+              <Paper elevation={3} sx={{ p: 3, textAlign: 'center', height: '100%' }}>
+                <AltRouteIcon sx={{ fontSize: 40, color: 'primary.main' }} />
+                <Typography variant="h6" component="h3" sx={{ fontWeight: 'bold', mt: 1 }}>
+                  Kilométrage illimité
+                </Typography>
+                <Typography variant="body2" sx={{ color: '#7f8c8d', mt: 1 }}>
+                  De nombreuses offres incluent le kilométrage illimité location Tunisie pour explorer le pays sans contrainte.
+                </Typography>
+              </Paper>
+            </Grid>
+            <Grid item xs={12} md={6} lg={3}>
+              <Paper elevation={3} sx={{ p: 3, textAlign: 'center', height: '100%' }}>
+                <CachedIcon sx={{ fontSize: 40, color: 'primary.main' }} />
+                <Typography variant="h6" component="h3" sx={{ fontWeight: 'bold', mt: 1 }}>
+                  Annulation flexible
+                </Typography>
+                <Typography variant="body2" sx={{ color: '#7f8c8d', mt: 1 }}>
+                  Souvent gratuite jusqu\u2019à J-2 selon l\u2019offre, vous gardez le contrôle de votre réservation.
+                </Typography>
+              </Paper>
+            </Grid>
+            <Grid item xs={12} md={6} lg={3}>
+              <Paper elevation={3} sx={{ p: 3, textAlign: 'center', height: '100%' }}>
+                <SecurityIcon sx={{ fontSize: 40, color: 'primary.main' }} />
+                <Typography variant="h6" component="h3" sx={{ fontWeight: 'bold', mt: 1 }}>
+                  Caution transparente
+                </Typography>
+                <Typography variant="body2" sx={{ color: '#7f8c8d', mt: 1 }}>
+                  Les dépôts de garantie et l\u2019assurance location voiture Tunisie sont clairement indiqués pour comparer facilement.
+                </Typography>
+              </Paper>
+            </Grid>
+            <Grid item xs={12} md={6} lg={3}>
+              <Paper elevation={3} sx={{ p: 3, textAlign: 'center', height: '100%' }}>
+                <DirectionsCarIcon sx={{ fontSize: 40, color: 'primary.main' }} />
+                <Typography variant="h6" component="h3" sx={{ fontWeight: 'bold', mt: 1 }}>
+                  Large choix de véhicules
+                </Typography>
+                <Typography variant="body2" sx={{ color: '#7f8c8d', mt: 1 }}>
+                  Boîte manuelle ou voiture automatique Tunisie location, citadines, SUV ou minivans : filtrez et choisissez facilement.
+                </Typography>
+              </Paper>
+            </Grid>
+          </Grid>
         </Box>
 
         <Box sx={{ mt: 8 }}>
@@ -297,10 +364,30 @@ const LocationVoitureTunisiePrixDinars = () => {
             Conseils pour économiser
           </Typography>
           <List sx={{ color: '#7f8c8d', mt: 2 }}>
-            <ListItem>Réservez tôt, surtout pour juillet et août</ListItem>
-            <ListItem>Comparez les prix entre l\u2019aéroport et le centre-ville</ListItem>
-            <ListItem>Évitez les réservations de dernière minute</ListItem>
-            <ListItem>Plus la durée est longue, plus le prix par jour baisse</ListItem>
+            <ListItem>
+              <ListItemIcon>
+                <CheckCircleIcon color="primary" />
+              </ListItemIcon>
+              <ListItemText primary="Réservez tôt, surtout pour juillet et août" />
+            </ListItem>
+            <ListItem>
+              <ListItemIcon>
+                <CheckCircleIcon color="primary" />
+              </ListItemIcon>
+              <ListItemText primary="Comparez les prix entre l’aéroport et le centre-ville" />
+            </ListItem>
+            <ListItem>
+              <ListItemIcon>
+                <CheckCircleIcon color="primary" />
+              </ListItemIcon>
+              <ListItemText primary="Évitez les réservations de dernière minute" />
+            </ListItem>
+            <ListItem>
+              <ListItemIcon>
+                <CheckCircleIcon color="primary" />
+              </ListItemIcon>
+              <ListItemText primary="Plus la durée est longue, plus le prix par jour baisse" />
+            </ListItem>
           </List>
         </Box>
 
@@ -308,36 +395,66 @@ const LocationVoitureTunisiePrixDinars = () => {
           <Typography variant="h4" component="h2" gutterBottom sx={{ fontWeight: 'bold', color: '#2c3e50' }}>
             FAQ
           </Typography>
-          <Typography variant="h5" component="h3" sx={{ fontWeight: 'bold', mt: 4 }}>
-            Quel est le prix moyen d\u2019une location en été en Tunisie ?
-          </Typography>
-          <Typography variant="body1" sx={{ color: '#7f8c8d', mt: 1 }}>
-            En haute saison, comptez généralement 100\u2013120 TND/j pour une citadine économique réservée à l\u2019avance.
-          </Typography>
-          <Typography variant="h5" component="h3" sx={{ fontWeight: 'bold', mt: 4 }}>
-            Faut-il un permis international pour louer en Tunisie ?
-          </Typography>
-          <Typography variant="body1" sx={{ color: '#7f8c8d', mt: 1 }}>
-            Un permis national lisible suffit pour un court séjour touristique. Le permis international n\u2019est pas toujours exigé.
-          </Typography>
-          <Typography variant="h5" component="h3" sx={{ fontWeight: 'bold', mt: 4 }}>
-            Peut-on louer une voiture automatique à Tunis (aéroport Tunis-Carthage) ?
-          </Typography>
-          <Typography variant="body1" sx={{ color: '#7f8c8d', mt: 1 }}>
-            Oui, de nombreuses agences proposent des voitures automatiques à Tunis et à l\u2019aéroport Tunis-Carthage.
-          </Typography>
-          <Typography variant="h5" component="h3" sx={{ fontWeight: 'bold', mt: 4 }}>
-            Quelle est la politique d\u2019annulation avec Plany.tn ?
-          </Typography>
-          <Typography variant="body1" sx={{ color: '#7f8c8d', mt: 1 }}>
-            La plupart des offres offrent une annulation gratuite jusqu\u201948 h avant la prise en charge.
-          </Typography>
-          <Typography variant="h5" component="h3" sx={{ fontWeight: 'bold', mt: 4 }}>
-            Quelle caution prévoir et comment la réduire ?
-          </Typography>
-          <Typography variant="body1" sx={{ color: '#7f8c8d', mt: 1 }}>
-            Préparez une caution de 800\u20131200 TND selon le modèle. Choisissez des offres avec assurance complète ou options r\u00E9duisant le d\u00E9p\u00F4t.
-          </Typography>
+          <Accordion sx={{ mt: 2 }}>
+            <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+              <Typography variant="h6" component="h3">
+                Quel est le prix moyen d’une location en été en Tunisie ?
+              </Typography>
+            </AccordionSummary>
+            <AccordionDetails>
+              <Typography variant="body1" sx={{ color: '#7f8c8d' }}>
+                En haute saison, comptez généralement 100–120 TND/j pour une citadine économique réservée à l’avance.
+              </Typography>
+            </AccordionDetails>
+          </Accordion>
+          <Accordion>
+            <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+              <Typography variant="h6" component="h3">
+                Faut-il un permis international pour louer en Tunisie ?
+              </Typography>
+            </AccordionSummary>
+            <AccordionDetails>
+              <Typography variant="body1" sx={{ color: '#7f8c8d' }}>
+                Un permis national lisible suffit pour un court séjour touristique. Le permis international n’est pas toujours exigé.
+              </Typography>
+            </AccordionDetails>
+          </Accordion>
+          <Accordion>
+            <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+              <Typography variant="h6" component="h3">
+                Peut-on louer une voiture automatique à Tunis (aéroport Tunis-Carthage) ?
+              </Typography>
+            </AccordionSummary>
+            <AccordionDetails>
+              <Typography variant="body1" sx={{ color: '#7f8c8d' }}>
+                Oui, de nombreuses agences proposent des voitures automatiques à Tunis et à l’aéroport Tunis-Carthage.
+              </Typography>
+            </AccordionDetails>
+          </Accordion>
+          <Accordion>
+            <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+              <Typography variant="h6" component="h3">
+                Quelle est la politique d’annulation avec Plany.tn ?
+              </Typography>
+            </AccordionSummary>
+            <AccordionDetails>
+              <Typography variant="body1" sx={{ color: '#7f8c8d' }}>
+                La plupart des offres offrent une annulation gratuite jusqu’48 h avant la prise en charge.
+              </Typography>
+            </AccordionDetails>
+          </Accordion>
+          <Accordion>
+            <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+              <Typography variant="h6" component="h3">
+                Quelle caution prévoir et comment la réduire ?
+              </Typography>
+            </AccordionSummary>
+            <AccordionDetails>
+              <Typography variant="body1" sx={{ color: '#7f8c8d' }}>
+                Préparez une caution de 800–1200 TND selon le modèle. Choisissez des offres avec assurance complète ou options réduisant le dépôt.
+              </Typography>
+            </AccordionDetails>
+          </Accordion>
         </Box>
 
         <Box sx={{ mt: 8, mb: 8 }}>


### PR DESCRIPTION
## Summary
- add SEO article page for Tunisia car rental prices in dinars with seasonal table and JSON-LD
- expose the new page through React router

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a776b5ca148333aed00c3cf9282959