### PR TITLE
feat(frontend): redirect users to previous page after sign-in

### DIFF
--- a/backend/src/services/UserService.ts
+++ b/backend/src/services/UserService.ts
@@ -173,6 +173,7 @@ export const signout = async (redirect = true) => {
 
   sessionStorage.clear()
   localStorage.removeItem('bc-user')
+  localStorage.removeItem('checkout')
   deleteAllCookies()
 
   await axiosInstance

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -94,6 +94,10 @@ const Header = ({
     },
   }
 
+  const signInUrl = `/sign-in?redirect=${encodeURIComponent(
+    window.location.pathname + window.location.search
+  )}`
+
   const handleAccountMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
     setAnchorEl(event.currentTarget)
   }
@@ -317,7 +321,7 @@ const Header = ({
                   <ListItemText primary={strings.CONTACT} />
                 </ListItemLink>
                 {env.isMobile() && !hideSignin && !isSignedIn && isLoaded && !loading && (
-                  <ListItemLink href="/sign-in">
+                  <ListItemLink href={signInUrl}>
                     <ListItemIcon><LoginIcon /></ListItemIcon>
                     <ListItemText primary={strings.SIGN_IN} />
                   </ListItemLink>
@@ -334,7 +338,15 @@ const Header = ({
                 </IconButton>
               )}
               {!hideSignin && !isSignedIn && isLoaded && !loading && (
-                <Button variant="contained" startIcon={<LoginIcon />} href="/sign-in" disableElevation fullWidth className="btn" style={{ minWidth: '180px' }}>
+                <Button
+                  variant="contained"
+                  startIcon={<LoginIcon />}
+                  href={signInUrl}
+                  disableElevation
+                  fullWidth
+                  className="btn"
+                  style={{ minWidth: '180px' }}
+                >
                   {strings.SIGN_IN}
                 </Button>
               )}
@@ -346,9 +358,17 @@ const Header = ({
             </div>
             <div className="header-mobile">
               {!hideSignin && !isSignedIn && isLoaded && !loading && (
-              <Button variant="contained" startIcon={<LoginIcon />} href="/sign-in" disableElevation fullWidth className="btn" style={{ minWidth: '180px' }}>
-                {strings.SIGN_IN}
-              </Button>
+                <Button
+                  variant="contained"
+                  startIcon={<LoginIcon />}
+                  href={signInUrl}
+                  disableElevation
+                  fullWidth
+                  className="btn"
+                  style={{ minWidth: '180px' }}
+                >
+                  {strings.SIGN_IN}
+                </Button>
               )}
               {isSignedIn && (
                 <IconButton onClick={handleNotificationsClick} className="btn">

--- a/frontend/src/pages/Checkout.tsx
+++ b/frontend/src/pages/Checkout.tsx
@@ -64,6 +64,10 @@ const Checkout = () => {
   const location = useLocation()
   const navigate = useNavigate()
 
+  const signInUrl = `/sign-in?redirect=${encodeURIComponent(
+    location.pathname + location.search
+  )}`
+
   const [user, setUser] = useState<bookcarsTypes.User>()
   const [car, setCar] = useState<bookcarsTypes.Car>()
   const [pickupLocation, setPickupLocation] = useState<bookcarsTypes.Location>()
@@ -640,7 +644,7 @@ const Checkout = () => {
                               <span>
                                 <span>{commonStrings.EMAIL_ALREADY_REGISTERED}</span>
                                 <span> </span>
-                                <a href={`/sign-in?c=${car._id}&p=${pickupLocation._id}&d=${dropOffLocation._id}&f=${from.getTime()}&t=${to.getTime()}&from=checkout`}>{strings.SIGN_IN}</a>
+                                <a href={signInUrl}>{strings.SIGN_IN}</a>
                               </span>
                             ))
                               || ''}
@@ -855,7 +859,7 @@ const Checkout = () => {
                     </Button>
                     )}
                     {((!clientSecret || (payLater)) && !user) && (
-                    <Button href="/sign-in" variant="contained" className="btn-checkout btn-margin-bottom" size="small" disabled={loading}>
+                    <Button href={signInUrl} variant="contained" className="btn-checkout btn-margin-bottom" size="small" disabled={loading}>
                       {
                           loading
                             ? <CircularProgress color="inherit" size={24} />

--- a/frontend/src/pages/Checkout.tsx
+++ b/frontend/src/pages/Checkout.tsx
@@ -346,20 +346,26 @@ const Checkout = () => {
     setUser(_user)
     setAuthenticated(_user !== undefined)
     setLanguage(UserService.getLanguage())
+    const state = (location.state as any) || (() => {
+      const stored = sessionStorage.getItem('checkout')
+      return stored ? JSON.parse(stored) : null
+    })()
 
-    const { state } = location
+    if (location.state) {
+      sessionStorage.setItem('checkout', JSON.stringify(location.state))
+    }
+
     if (!state) {
       setNoMatch(true)
       return
     }
 
-    const { carId } = state
-    const { pickupLocationId } = state
-    const { dropOffLocationId } = state
-    const { from: _from } = state
-    const { to: _to } = state
+    const { carId, pickupLocationId, dropOffLocationId, from: fromStr, to: toStr } = state
 
-    if (!carId || !pickupLocationId || !dropOffLocationId || !_from || !_to) {
+    const _from = new Date(fromStr)
+    const _to = new Date(toStr)
+
+    if (!carId || !pickupLocationId || !dropOffLocationId || Number.isNaN(_from.getTime()) || Number.isNaN(_to.getTime())) {
       setNoMatch(true)
       return
     }

--- a/frontend/src/pages/Checkout.tsx
+++ b/frontend/src/pages/Checkout.tsx
@@ -347,12 +347,16 @@ const Checkout = () => {
     setAuthenticated(_user !== undefined)
     setLanguage(UserService.getLanguage())
     const state = (location.state as any) || (() => {
-      const stored = sessionStorage.getItem('checkout')
-      return stored ? JSON.parse(stored) : null
+      const stored = localStorage.getItem('checkout')
+      if (stored) {
+        localStorage.removeItem('checkout')
+        return JSON.parse(stored)
+      }
+      return null
     })()
 
-    if (location.state) {
-      sessionStorage.setItem('checkout', JSON.stringify(location.state))
+    if (location.state && !_user) {
+      localStorage.setItem('checkout', JSON.stringify(location.state))
     }
 
     if (!state) {

--- a/frontend/src/pages/SignIn.tsx
+++ b/frontend/src/pages/SignIn.tsx
@@ -57,15 +57,11 @@ const SignIn = () => {
           setError(false)
 
           const params = new URLSearchParams(window.location.search)
-          if (params.has('from')) {
-            const from = params.get('from')
-            if (from === 'checkout') {
-              navigate(`/checkout${window.location.search}`)
-            } else {
-              navigate(0)
-            }
+          const redirect = params.get('redirect')
+          if (redirect) {
+            navigate(decodeURIComponent(redirect))
           } else {
-            navigate(0)
+            navigate(`/${window.location.search}`)
           }
         }
       } else {
@@ -89,13 +85,9 @@ const SignIn = () => {
 
     if (user) {
       const params = new URLSearchParams(window.location.search)
-      if (params.has('from')) {
-        const from = params.get('from')
-        if (from === 'checkout') {
-          navigate(`/checkout${window.location.search}`)
-        } else {
-          navigate(`/${window.location.search}`)
-        }
+      const redirect = params.get('redirect')
+      if (redirect) {
+        navigate(decodeURIComponent(redirect))
       } else {
         navigate(`/${window.location.search}`)
       }

--- a/frontend/src/services/UserService.ts
+++ b/frontend/src/services/UserService.ts
@@ -152,6 +152,7 @@ export const signout = async (redirect = true, redirectSignin = false) => {
 
   sessionStorage.clear()
   localStorage.removeItem('bc-user')
+  localStorage.removeItem('checkout')
   deleteAllCookies()
 
   await axiosInstance

--- a/frontend/src/services/UserService.ts
+++ b/frontend/src/services/UserService.ts
@@ -152,7 +152,7 @@ export const signout = async (redirect = true, redirectSignin = false) => {
 
   sessionStorage.clear()
   localStorage.removeItem('bc-user')
-  localStorage.removeItem('checkout')
+  // localStorage.removeItem('checkout')
   deleteAllCookies()
 
   await axiosInstance


### PR DESCRIPTION
## Summary
- preserve source page by appending a redirect parameter to sign-in links
- send authenticated users back to the stored page or home if none
- ensure checkout prompts also return users to their previous location

## Testing
- `cd frontend && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a783a41da08333a888ec58dd2ccf60