### PR TITLE
feat(frontend): use @react-oauth/google for Google sign-in

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "@mui/material": "^6.1.7",
     "@mui/x-data-grid": "^7.22.2",
     "@mui/x-date-pickers": "^7.22.2",
+    "@react-oauth/google": "^0.11.0",
     "@stripe/react-stripe-js": "^2.9.0",
     "@stripe/stripe-js": "^4.10.0",
     "@types/leaflet": "^1.9.14",

--- a/frontend/src/components/SocialLogin.tsx
+++ b/frontend/src/components/SocialLogin.tsx
@@ -3,8 +3,8 @@ import { useNavigate } from 'react-router-dom'
 import {
   LoginSocialFacebook,
   LoginSocialApple,
-  LoginSocialGoogle,
 } from 'reactjs-social-login'
+import { useGoogleLogin } from '@react-oauth/google'
 import * as bookcarsTypes from ':bookcars-types'
 import { IResolveParams } from '@/types'
 import { strings as commonStrings } from '@/lang/common'
@@ -77,6 +77,30 @@ const SocialLogin = ({
     return email
   }
 
+  const googleLogin = useGoogleLogin({
+    onSuccess: async ({ access_token: accessToken }) => {
+      try {
+        const response = await fetch('https://www.googleapis.com/oauth2/v3/userinfo', {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        })
+        const profile = await response.json()
+        loginSuccess(
+          bookcarsTypes.SocialSignInType.Google,
+          accessToken,
+          profile.email,
+          profile.name || profile.email,
+          profile.picture,
+        )
+      } catch (err) {
+        loginError(err)
+      }
+    },
+    onError: loginError,
+    scope: 'openid profile email',
+  })
+
   return (
     <div className={`${className ? `${className} ` : ''}social-login`}>
       <div className="separator">
@@ -127,23 +151,22 @@ const SocialLogin = ({
         )}
 
         {google && (
-          <LoginSocialGoogle
-            client_id={env.GG_APP_ID}
-            redirect_uri={REDIRECT_URI}
-            scope="openid profile email"
-            discoveryDocs="claims_supported"
-            onResolve={({ data }: IResolveParams) => {
-              loginSuccess(bookcarsTypes.SocialSignInType.Google, data?.access_token, data?.email, data?.name || data?.email, data?.picture)
-            }}
-            onReject={(err: any) => {
-              loginError(err)
-            }}
-          >
-            <div className="social-button">
+          <div className="social">
+            <div
+              className="social-button"
+              role="button"
+              tabIndex={0}
+              onClick={() => googleLogin()}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  googleLogin()
+                }
+              }}
+            >
               <img src={GoogleIcon} alt="Google" className="social-logo" />
               <span>Connexion avec Google</span>
             </div>
-          </LoginSocialGoogle>
+          </div>
         )}
       </div>
       <div className="separator">

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,6 +4,7 @@ import { ToastContainer } from 'react-toastify'
 import { createTheme, ThemeProvider } from '@mui/material/styles'
 import CssBaseline from '@mui/material/CssBaseline'
 import { extendTheme } from '@mui/joy/styles'
+import { GoogleOAuthProvider } from '@react-oauth/google'
 
 import { frFR as corefrFR, enUS as coreenUS, elGR as coreelGR } from '@mui/material/locale'
 import { frFR, enUS, elGR } from '@mui/x-date-pickers/locales'
@@ -256,20 +257,22 @@ const theme = createTheme(
 )
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
-  <ThemeProvider theme={theme}>
-    <CssBaseline>
-      <App />
-      <ToastContainer
-        position="bottom-right"
-        autoClose={5000}
-        hideProgressBar={false}
-        newestOnTop={false}
-        closeOnClick
-        pauseOnFocusLoss={false}
-        draggable={false}
-        pauseOnHover
-        theme="dark"
-      />
-    </CssBaseline>
-  </ThemeProvider>,
+  <GoogleOAuthProvider clientId={env.GG_APP_ID}>
+    <ThemeProvider theme={theme}>
+      <CssBaseline>
+        <App />
+        <ToastContainer
+          position="bottom-right"
+          autoClose={5000}
+          hideProgressBar={false}
+          newestOnTop={false}
+          closeOnClick
+          pauseOnFocusLoss={false}
+          draggable={false}
+          pauseOnHover
+          theme="dark"
+        />
+      </CssBaseline>
+    </ThemeProvider>
+  </GoogleOAuthProvider>,
 )


### PR DESCRIPTION
## Summary
- replace `reactjs-social-login` Google implementation with `@react-oauth/google`
- wrap app with `GoogleOAuthProvider`
- add `@react-oauth/google` dependency

## Testing
- `npm run lint`
- `npm install @react-oauth/google@latest` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@react-oauth%2fgoogle)*

------
https://chatgpt.com/codex/tasks/task_e_68b4a9cbdb308333a8248133cc3f6510