### PR TITLE
feat: add Plany commission pricing

### DIFF
--- a/api/src/config/env.config.ts
+++ b/api/src/config/env.config.ts
@@ -329,6 +329,22 @@ export const DEFAULT_LANGUAGE = __env__('BC_DEFAULT_LANGUAGE', false, 'fr')
  */
 export const MINIMUM_AGE = Number.parseInt(__env__('BC_MINIMUM_AGE', false, '21'), 10)
 
+const parseCommissionDate = (value?: string) => {
+  if (!value) {
+    return new Date('2025-01-01T00:00:00Z')
+  }
+
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? new Date('2025-01-01T00:00:00Z') : date
+}
+
+export const COMMISSION_ENABLED = helper.StringToBoolean(__env__('XXXX__COMMISSION_ENABLED', false, 'true'))
+const parsedCommissionRate = Number.parseFloat(__env__('XXXX__COMMISSION_RATE', false, '5'))
+export const COMMISSION_RATE = Number.isNaN(parsedCommissionRate) ? 5 : parsedCommissionRate
+export const COMMISSION_EFFECTIVE_DATE = parseCommissionDate(__env__('XXXX__COMMISSION_EFFECTIVE_DATE', false, '2025-01-01'))
+const parsedCommissionThreshold = Number.parseInt(__env__('XXXX__COMMISSION_MONTHLY_THRESHOLD', false, '50'), 10)
+export const COMMISSION_MONTHLY_THRESHOLD = Number.isNaN(parsedCommissionThreshold) ? 50 : parsedCommissionThreshold
+
 /**
  * Expo push access token.
  *
@@ -546,6 +562,8 @@ export interface Booking extends Document {
   _additionalDriver?: Types.ObjectId
   cancelRequest?: boolean
   price: number
+  commissionRate?: number
+  commissionTotal?: number
   sessionId?: string
   paymentIntentId?: string
   customerId?: string

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -4,9 +4,17 @@ import fs from 'node:fs/promises'
 import http from 'node:http'
 import https, { ServerOptions } from 'node:https'
 import * as env from './config/env.config'
+import { setCommissionConfig } from ':bookcars-helper'
 import * as databaseHelper from './common/databaseHelper'
 import app from './app'
 import * as logger from './common/logger'
+
+setCommissionConfig({
+  enabled: env.COMMISSION_ENABLED,
+  rate: env.COMMISSION_RATE,
+  effectiveDate: env.COMMISSION_EFFECTIVE_DATE,
+  monthlyThreshold: env.COMMISSION_MONTHLY_THRESHOLD,
+})
 
 if (
   await databaseHelper.connect(env.DB_URI, env.DB_SSL, env.DB_DEBUG) && await databaseHelper.initialize()

--- a/api/src/models/Booking.ts
+++ b/api/src/models/Booking.ts
@@ -88,6 +88,16 @@ const bookingSchema = new Schema<env.Booking>(
       type: Number,
       required: [true, "can't be blank"],
     },
+    commissionRate: {
+      type: Number,
+      default: 0,
+      min: 0,
+    },
+    commissionTotal: {
+      type: Number,
+      default: 0,
+      min: 0,
+    },
     cancelRequest: {
       type: Boolean,
       default: false,

--- a/backend/src/config/env.config.ts
+++ b/backend/src/config/env.config.ts
@@ -61,6 +61,24 @@ const env = {
       ? Const.PAGINATION_MODE.INFINITE_SCROLL
       : Const.PAGINATION_MODE.CLASSIC,
   CURRENCY: import.meta.env.VITE_BC_CURRENCY || '$',
+  COMMISSION_ENABLED:
+    (import.meta.env.VITE_XXXX__COMMISSION_ENABLED && import.meta.env.VITE_XXXX__COMMISSION_ENABLED.toLowerCase()) === 'true',
+  COMMISSION_RATE:
+    (() => {
+      const value = Number.parseFloat(String(import.meta.env.VITE_XXXX__COMMISSION_RATE ?? '5'))
+      return Number.isNaN(value) ? 5 : value
+    })(),
+  COMMISSION_EFFECTIVE_DATE:
+    (() => {
+      const value = String(import.meta.env.VITE_XXXX__COMMISSION_EFFECTIVE_DATE || '2025-01-01')
+      const date = new Date(value)
+      return Number.isNaN(date.getTime()) ? new Date('2025-01-01T00:00:00Z') : date
+    })(),
+  COMMISSION_MONTHLY_THRESHOLD:
+    (() => {
+      const value = Number.parseInt(String(import.meta.env.VITE_XXXX__COMMISSION_MONTHLY_THRESHOLD || '50'), 10)
+      return Number.isNaN(value) ? 50 : value
+    })(),
   DEPOSIT_FILTER_VALUE_1: Number.parseInt(String(import.meta.env.VITE_BC_DEPOSIT_FILTER_VALUE_1), 10),
   DEPOSIT_FILTER_VALUE_2: Number.parseInt(String(import.meta.env.VITE_BC_DEPOSIT_FILTER_VALUE_2), 10),
   DEPOSIT_FILTER_VALUE_3: Number.parseInt(String(import.meta.env.VITE_BC_DEPOSIT_FILTER_VALUE_3), 10),

--- a/backend/src/main.tsx
+++ b/backend/src/main.tsx
@@ -8,6 +8,7 @@ import { frFR as corefrFR, enUS as coreenUS } from '@mui/material/locale'
 import { frFR, enUS } from '@mui/x-date-pickers/locales'
 import { frFR as dataGridfrFR, enUS as dataGridenUS } from '@mui/x-data-grid/locales'
 import { disableDevTools } from ':disable-react-devtools'
+import { setCommissionConfig } from ':bookcars-helper'
 import * as helper from '@/common/helper'
 import * as UserService from '@/services/UserService'
 import { strings as commonStrings } from '@/lang/common'
@@ -21,6 +22,13 @@ import '@/assets/css/index.css'
 if (import.meta.env.VITE_NODE_ENV === 'production') {
   disableDevTools()
 }
+
+setCommissionConfig({
+  enabled: env.COMMISSION_ENABLED,
+  rate: env.COMMISSION_RATE,
+  effectiveDate: env.COMMISSION_EFFECTIVE_DATE,
+  monthlyThreshold: env.COMMISSION_MONTHLY_THRESHOLD,
+})
 
 let language = env.DEFAULT_LANGUAGE
 const user = JSON.parse(localStorage.getItem('bc-user') ?? 'null')

--- a/frontend/src/config/env.config.ts
+++ b/frontend/src/config/env.config.ts
@@ -64,6 +64,24 @@ const env = {
    * */
   STRIPE_CURRENCY_CODE: String(import.meta.env.VITE_BC_STRIPE_CURRENCY_CODE || 'USD'),
   CURRENCY: import.meta.env.VITE_BC_CURRENCY || '$',
+  COMMISSION_ENABLED:
+    (import.meta.env.VITE_XXXX__COMMISSION_ENABLED && import.meta.env.VITE_XXXX__COMMISSION_ENABLED.toLowerCase()) === 'true',
+  COMMISSION_RATE:
+    (() => {
+      const value = Number.parseFloat(String(import.meta.env.VITE_XXXX__COMMISSION_RATE ?? '5'))
+      return Number.isNaN(value) ? 5 : value
+    })(),
+  COMMISSION_EFFECTIVE_DATE:
+    (() => {
+      const value = String(import.meta.env.VITE_XXXX__COMMISSION_EFFECTIVE_DATE || '2025-01-01')
+      const date = new Date(value)
+      return Number.isNaN(date.getTime()) ? new Date('2025-01-01T00:00:00Z') : date
+    })(),
+  COMMISSION_MONTHLY_THRESHOLD:
+    (() => {
+      const value = Number.parseInt(String(import.meta.env.VITE_XXXX__COMMISSION_MONTHLY_THRESHOLD || '50'), 10)
+      return Number.isNaN(value) ? 50 : value
+    })(),
   SET_LANGUAGE_FROM_IP: (import.meta.env.VITE_BC_SET_LANGUAGE_FROM_IP && import.meta.env.VITE_BC_SET_LANGUAGE_FROM_IP.toLowerCase()) === 'true',
   GOOGLE_ANALYTICS_ENABLED: (import.meta.env.VITE_BC_GOOGLE_ANALYTICS_ENABLED && import.meta.env.VITE_BC_GOOGLE_ANALYTICS_ENABLED.toLowerCase()) === 'true',
   GOOGLE_ANALYTICS_ID: String(import.meta.env.VITE_BC_GOOGLE_ANALYTICS_ID),

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -10,6 +10,7 @@ import { frFR as corefrFR, enUS as coreenUS, elGR as coreelGR } from '@mui/mater
 import { frFR, enUS, elGR } from '@mui/x-date-pickers/locales'
 import { frFR as dataGridfrFR, enUS as dataGridenUS, elGR as dataGridelGR } from '@mui/x-data-grid/locales'
 import { disableDevTools } from ':disable-react-devtools'
+import { setCommissionConfig } from ':bookcars-helper'
 import * as helper from '@/common/helper'
 import * as UserService from '@/services/UserService'
 import env from '@/config/env.config'
@@ -56,6 +57,13 @@ import '@/assets/css/index.css'
 if (env.isProduction) {
   disableDevTools()
 }
+
+setCommissionConfig({
+  enabled: env.COMMISSION_ENABLED,
+  rate: env.COMMISSION_RATE,
+  effectiveDate: env.COMMISSION_EFFECTIVE_DATE,
+  monthlyThreshold: env.COMMISSION_MONTHLY_THRESHOLD,
+})
 
 let language = env.DEFAULT_LANGUAGE
 const user = JSON.parse(localStorage.getItem('bc-user') ?? 'null')

--- a/frontend/src/pages/Booking.tsx
+++ b/frontend/src/pages/Booking.tsx
@@ -79,10 +79,14 @@ const Booking = () => {
         if (_car && from && to) {
           const _booking = bookcarsHelper.clone(booking)
           _booking.car = _car
-          const _price = bookcarsHelper.calculateTotalPrice(_car, from, to, _booking)
+          const breakdown = bookcarsHelper.calculatePriceBreakdown(_car, from, to, _booking)
+
+          _booking.price = breakdown.totalPrice
+          _booking.commissionRate = breakdown.commissionRate
+          _booking.commissionTotal = breakdown.commissionTotal
 
           setBooking(_booking)
-          setPrice(_price)
+          setPrice(breakdown.totalPrice)
           setCar(newCar)
         } else {
           helper.error()
@@ -106,14 +110,19 @@ const Booking = () => {
     if (booking && booking.car) {
       booking.cancellation = e.target.checked
 
-      const _price = bookcarsHelper.calculateTotalPrice(
+      const breakdown = bookcarsHelper.calculatePriceBreakdown(
         booking.car as bookcarsTypes.Car,
         new Date(booking.from),
         new Date(booking.to),
         booking as bookcarsTypes.CarOptions
       )
+
+      booking.price = breakdown.totalPrice
+      booking.commissionRate = breakdown.commissionRate
+      booking.commissionTotal = breakdown.commissionTotal
+
       setBooking(booking)
-      setPrice(_price)
+      setPrice(breakdown.totalPrice)
       setCancellation(booking.cancellation)
     }
   }
@@ -122,14 +131,19 @@ const Booking = () => {
     if (booking && booking.car) {
       booking.amendments = e.target.checked
 
-      const _price = bookcarsHelper.calculateTotalPrice(
+      const breakdown = bookcarsHelper.calculatePriceBreakdown(
         booking.car as bookcarsTypes.Car,
         new Date(booking.from),
         new Date(booking.to),
         booking as bookcarsTypes.CarOptions
       )
+
+      booking.price = breakdown.totalPrice
+      booking.commissionRate = breakdown.commissionRate
+      booking.commissionTotal = breakdown.commissionTotal
+
       setBooking(booking)
-      setPrice(_price)
+      setPrice(breakdown.totalPrice)
       setAmendments(booking.amendments)
     }
   }
@@ -138,14 +152,19 @@ const Booking = () => {
     if (booking && booking.car) {
       booking.collisionDamageWaiver = e.target.checked
 
-      const _price = bookcarsHelper.calculateTotalPrice(
+      const breakdown = bookcarsHelper.calculatePriceBreakdown(
         booking.car as bookcarsTypes.Car,
         new Date(booking.from),
         new Date(booking.to),
         booking as bookcarsTypes.CarOptions
       )
+
+      booking.price = breakdown.totalPrice
+      booking.commissionRate = breakdown.commissionRate
+      booking.commissionTotal = breakdown.commissionTotal
+
       setBooking(booking)
-      setPrice(_price)
+      setPrice(breakdown.totalPrice)
       setCollisionDamageWaiver(booking.collisionDamageWaiver)
     }
   }
@@ -154,14 +173,19 @@ const Booking = () => {
     if (booking && booking.car) {
       booking.theftProtection = e.target.checked
 
-      const _price = bookcarsHelper.calculateTotalPrice(
+      const breakdown = bookcarsHelper.calculatePriceBreakdown(
         booking.car as bookcarsTypes.Car,
         new Date(booking.from),
         new Date(booking.to),
         booking as bookcarsTypes.CarOptions
       )
+
+      booking.price = breakdown.totalPrice
+      booking.commissionRate = breakdown.commissionRate
+      booking.commissionTotal = breakdown.commissionTotal
+
       setBooking(booking)
-      setPrice(_price)
+      setPrice(breakdown.totalPrice)
       setTheftProtection(booking.theftProtection)
     }
   }
@@ -170,14 +194,19 @@ const Booking = () => {
     if (booking && booking.car) {
       booking.fullInsurance = e.target.checked
 
-      const _price = bookcarsHelper.calculateTotalPrice(
+      const breakdown = bookcarsHelper.calculatePriceBreakdown(
         booking.car as bookcarsTypes.Car,
         new Date(booking.from),
         new Date(booking.to),
         booking as bookcarsTypes.CarOptions
       )
+
+      booking.price = breakdown.totalPrice
+      booking.commissionRate = breakdown.commissionRate
+      booking.commissionTotal = breakdown.commissionTotal
+
       setBooking(booking)
-      setPrice(_price)
+      setPrice(breakdown.totalPrice)
       setFullInsurance(booking.fullInsurance)
     }
   }
@@ -186,14 +215,19 @@ const Booking = () => {
     if (booking && booking.car) {
       booking.additionalDriver = e.target.checked
 
-      const _price = bookcarsHelper.calculateTotalPrice(
+      const breakdown = bookcarsHelper.calculatePriceBreakdown(
         booking.car as bookcarsTypes.Car,
         new Date(booking.from),
         new Date(booking.to),
         booking as bookcarsTypes.CarOptions
       )
+
+      booking.price = breakdown.totalPrice
+      booking.commissionRate = breakdown.commissionRate
+      booking.commissionTotal = breakdown.commissionTotal
+
       setBooking(booking)
-      setPrice(_price)
+      setPrice(breakdown.totalPrice)
       setAdditionalDriver(booking.additionalDriver)
     }
   }
@@ -222,7 +256,9 @@ const Booking = () => {
         theftProtection,
         collisionDamageWaiver,
         fullInsurance,
-        price
+        price,
+        commissionRate: booking.commissionRate,
+        commissionTotal: booking.commissionTotal,
       }
 
       const payload = { booking: _booking }
@@ -369,15 +405,19 @@ const Booking = () => {
                     if (_from) {
                       booking.from = _from
 
-                      const _price = bookcarsHelper.calculateTotalPrice(
+                      const breakdown = bookcarsHelper.calculatePriceBreakdown(
                         booking.car as bookcarsTypes.Car,
                         new Date(booking.from),
                         new Date(booking.to),
                         booking as bookcarsTypes.CarOptions
                       )
-                      booking.price = _price
+
+                      booking.price = breakdown.totalPrice
+                      booking.commissionRate = breakdown.commissionRate
+                      booking.commissionTotal = breakdown.commissionTotal
+
                       setBooking(booking)
-                      setPrice(_price)
+                      setPrice(breakdown.totalPrice)
                       setFrom(_from)
                       setMinDate(_from)
                     }
@@ -396,15 +436,19 @@ const Booking = () => {
                     if (_to) {
                       booking.to = _to
 
-                      const _price = bookcarsHelper.calculateTotalPrice(
+                      const breakdown = bookcarsHelper.calculatePriceBreakdown(
                         booking.car as bookcarsTypes.Car,
                         new Date(booking.from),
                         new Date(booking.to),
                         booking as bookcarsTypes.CarOptions
                       )
-                      booking.price = _price
+
+                      booking.price = breakdown.totalPrice
+                      booking.commissionRate = breakdown.commissionRate
+                      booking.commissionTotal = breakdown.commissionTotal
+
                       setBooking(booking)
-                      setPrice(_price)
+                      setPrice(breakdown.totalPrice)
                       setTo(_to)
                     }
                   }}

--- a/frontend/src/pages/Checkout.tsx
+++ b/frontend/src/pages/Checkout.tsx
@@ -255,6 +255,25 @@ const Checkout = () => {
       let driver: bookcarsTypes.User | undefined
       let _additionalDriver: bookcarsTypes.AdditionalDriver | undefined
 
+      const options: bookcarsTypes.CarOptions = {
+        cancellation,
+        amendments,
+        theftProtection,
+        collisionDamageWaiver,
+        fullInsurance,
+        additionalDriver,
+      }
+
+      const breakdown = car && from && to
+        ? bookcarsHelper.calculatePriceBreakdown(car, from, to, options)
+        : undefined
+
+      const finalPrice = breakdown?.totalPrice ?? price
+
+      if (breakdown) {
+        setPrice(breakdown.totalPrice)
+      }
+
       const booking: bookcarsTypes.Booking = {
         supplier: car?.supplier._id as string,
         car: car ? car._id : '',
@@ -270,7 +289,9 @@ const Checkout = () => {
         collisionDamageWaiver,
         fullInsurance,
         additionalDriver,
-        price,
+        price: finalPrice,
+        commissionRate: breakdown?.commissionRate,
+        commissionTotal: breakdown?.commissionTotal,
       }
 
       if (adRequired && additionalDriver && addiontalDriverBirthDate) {
@@ -289,7 +310,7 @@ const Checkout = () => {
       let _sessionId: string | undefined
       if (!payLater) {
         const payload: bookcarsTypes.CreatePaymentPayload = {
-          amount: price,
+          amount: finalPrice,
           currency: env.STRIPE_CURRENCY_CODE,
           locale: language,
           receiptEmail: (!authenticated ? driver?.email : user?.email) as string,

--- a/packages/bookcars-types/index.ts
+++ b/packages/bookcars-types/index.ts
@@ -110,6 +110,8 @@ export interface Booking {
   _additionalDriver?: string | AdditionalDriver
   cancelRequest?: boolean
   price?: number
+  commissionRate?: number
+  commissionTotal?: number
   sessionId?: string
   paymentIntentId?: string
   customerId?: string


### PR DESCRIPTION
## Summary
- add shared commission configuration utilities and price breakdown calculations
- apply commission-aware pricing across the frontend, backend, and API while storing the applied rate and total on bookings
- expose commission environment variables and update models to persist the new commission metadata

## Testing
- npm run lint (frontend)
- npm run lint (api)
- npm test (api)


------
https://chatgpt.com/codex/tasks/task_e_68d19f08b4dc8333bdf11742198d6970