### PR TITLE
fix: include overlapping bookings in commissions

### DIFF
--- a/api/src/controllers/commissionController.ts
+++ b/api/src/controllers/commissionController.ts
@@ -171,8 +171,9 @@ const computeCommissionData = async (
   const bookingsAggregation = await Booking.aggregate([
     {
       $match: {
-        from: { $gte: effectiveStart, $lt: end },
         expireAt: null,
+        from: { $lt: end },
+        to: { $gte: effectiveStart },
       },
     },
     {
@@ -519,8 +520,9 @@ const loadAgencyCommissionDetail = async (
   const bookings = effectiveStart.getTime() < end.getTime()
     ? await Booking.find({
       supplier: supplierObjectId,
-      from: { $gte: effectiveStart, $lt: end },
       expireAt: null,
+      from: { $lt: end },
+      to: { $gte: effectiveStart },
     })
       .sort({ from: 1 })
       .lean()


### PR DESCRIPTION
## Summary
- include bookings that overlap the selected period when computing monthly commissions
- update agency commission detail queries to use the same overlap logic

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d31fba0b808333843e338318b80ee3