### PR TITLE
feat(backend): refine agency commissions layout

### DIFF
--- a/backend/src/assets/css/agency-commissions.css
+++ b/backend/src/assets/css/agency-commissions.css
@@ -38,8 +38,9 @@
 
 .agency-commissions .ac-kpis {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 16px;
+  width: 100%;
 }
 
 .agency-commissions .ac-kpi-card {
@@ -57,11 +58,25 @@
 }
 
 .agency-commissions .ac-table-footer {
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
   align-items: center;
   gap: 16px;
   padding: 8px 4px 0;
+  width: 100%;
+}
+
+.agency-commissions .ac-table-count {
+  justify-self: start;
+}
+
+.agency-commissions .ac-page-size {
+  justify-self: center;
+  min-width: 150px;
+}
+
+.agency-commissions .ac-table-pagination {
+  justify-self: end;
 }
 
 .ac-drawer-content {
@@ -197,6 +212,12 @@
   gap: 16px;
 }
 
+@media (max-width: 1280px) {
+  .agency-commissions .ac-kpis {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
 @media (max-width: 768px) {
   .agency-commissions {
     padding: 16px;
@@ -208,6 +229,30 @@
 
   .agency-commissions .ac-filters-card {
     padding: 16px;
+  }
+
+  .agency-commissions .ac-kpis {
+    grid-template-columns: 1fr;
+  }
+
+  .agency-commissions .ac-table-footer {
+    grid-template-columns: 1fr;
+    justify-items: stretch;
+    gap: 12px;
+  }
+
+  .agency-commissions .ac-table-count {
+    justify-self: stretch;
+    text-align: center;
+  }
+
+  .agency-commissions .ac-page-size {
+    justify-self: stretch;
+  }
+
+  .agency-commissions .ac-table-pagination {
+    justify-self: stretch;
+    justify-content: center;
   }
 
   .ac-drawer-content {

--- a/backend/src/pages/AgencyCommissions.tsx
+++ b/backend/src/pages/AgencyCommissions.tsx
@@ -36,6 +36,7 @@ import {
   TableHead,
   TableRow,
   InputAdornment,
+  Link,
 } from '@mui/material'
 import { SelectChangeEvent } from '@mui/material/Select'
 import {
@@ -828,14 +829,6 @@ const AgencyCommissions = () => {
                   control={<Switch checked={aboveThreshold} onChange={handleAboveThresholdChange} />}
                   label={strings.FILTER_ABOVE_THRESHOLD}
                 />
-                <FormControl size="small" sx={{ minWidth: 140 }}>
-                  <InputLabel>{strings.ROWS_PER_PAGE}</InputLabel>
-                  <Select value={pageSize} label={strings.ROWS_PER_PAGE} onChange={handlePageSizeChange}>
-                    {[10, 25, 50].map((sizeOption) => (
-                      <MenuItem key={sizeOption} value={sizeOption}>{sizeOption}</MenuItem>
-                    ))}
-                  </Select>
-                </FormControl>
                 <Stack direction="row" spacing={1} alignItems="center" sx={{ ml: { lg: 'auto' } }}>
                   <Tooltip title={strings.PREVIOUS_MONTH}>
                     <span>
@@ -947,15 +940,21 @@ const AgencyCommissions = () => {
                       return (
                         <TableRow key={agency.id} hover>
                           <TableCell>
-                            <Stack direction="row" spacing={1} alignItems="center">
-                              <Box>
-                                <Typography variant="body2" fontWeight={600}>{agency.name}</Typography>
-                                {agency.email && (
-                                  <Typography variant="caption" color="text.secondary">{agency.email}</Typography>
-                                )}
-                              </Box>
-                              {agency.city && <Chip size="small" label={agency.city} />}
-                            </Stack>
+                            <Typography
+                              component={Link}
+                              href={`/supplier?c=${agency.id}`}
+                              variant="body2"
+                              fontWeight={600}
+                              color="primary"
+                              sx={{
+                                textDecoration: 'none',
+                                '&:hover': {
+                                  textDecoration: 'underline',
+                                },
+                              }}
+                            >
+                              {agency.name}
+                            </Typography>
                           </TableCell>
                           <TableCell align="right">{formatNumber(row.reservations, language)}</TableCell>
                           <TableCell align="right">{formatCurrency(row.grossTurnover)}</TableCell>
@@ -999,12 +998,20 @@ const AgencyCommissions = () => {
             </Paper>
 
             <Box className="ac-table-footer">
-              <Typography variant="body2" color="text.secondary">
+              <Typography variant="body2" color="text.secondary" className="ac-table-count">
                 {rowCount === 0
                   ? `0 ${commonStrings.OF} 0`
                   : `${paginationFrom}–${paginationTo} ${commonStrings.OF} ${rowCount}`}
               </Typography>
-              <Stack direction="row" spacing={1}>
+              <FormControl size="small" className="ac-page-size" variant="outlined">
+                <InputLabel>{strings.ROWS_PER_PAGE}</InputLabel>
+                <Select value={pageSize} label={strings.ROWS_PER_PAGE} onChange={handlePageSizeChange}>
+                  {[10, 25, 50].map((sizeOption) => (
+                    <MenuItem key={sizeOption} value={sizeOption}>{sizeOption}</MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+              <Stack direction="row" spacing={1} className="ac-table-pagination">
                 <Button size="small" variant="outlined" onClick={handlePreviousPage} disabled={isPreviousDisabled}>
                   {strings.TABLE_PREVIOUS}
                 </Button>


### PR DESCRIPTION
## Summary
- make agency names clickable in the commissions table and link to the supplier detail view
- move the rows-per-page selector to the bottom footer so it is centered beneath the table controls
- expand the KPI cards layout to span the full width with responsive adjustments

## Testing
- npm run lint *(fails: ESLint 9 expects eslint.config.js; repository still relies on .eslintrc and dependencies could not be installed due to registry restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d7f3d4bb4c833387f9a2f1d44b35f5