### PR TITLE
feat(backend): update commission guidance on car forms

### DIFF
--- a/backend/src/lang/create-car.ts
+++ b/backend/src/lang/create-car.ts
@@ -20,9 +20,16 @@ const strings = new LocalizedStrings({
     AGENCY_PRICE_COLUMN_LABEL: `Prix agence (${commonStrings.CURRENCY}${commonStrings.DAILY})`,
     CLIENT_PRICE_COLUMN_LABEL: `Prix client (${commonStrings.CURRENCY}${commonStrings.DAILY})`,
     COMMISSION_COLUMN_LABEL: `Commission (${commonStrings.CURRENCY}${commonStrings.DAILY})`,
-    CLIENT_PRICE_INFO_TITLE: 'Affichage des prix côté client',
-    CLIENT_PRICE_INFO_BODY:
-      "Plany calcule le prix affiché au client à partir du prix agence, en ajoutant la commission Plany. Les remises de longue durée s'appliquent ensuite sur le prix affiché. Les prix spéciaux par période remplacent le prix par défaut lorsqu'ils sont applicables.",
+    CLIENT_PRICE_INFO_TITLE: 'Information sur la commission Plany',
+    CLIENT_PRICE_INFO_INTRO:
+      'À partir du {date} (configurable dans le fichier .env), chaque réservation inclura une commission de {rate} ajoutée automatiquement par Plany au prix agence que vous saisissez.',
+    CLIENT_PRICE_INFO_FORMULA: '👉 Le prix affiché au client = Prix agence + Commission Plany.',
+    CLIENT_PRICE_INFO_EXAMPLE:
+      'Exemple : Prix agence = {agencyPrice}, commission = {rate} ({commissionAmount}) → Prix client = {clientPrice}.',
+    CLIENT_PRICE_INFO_COLLECTION:
+      'La commission est collectée par votre agence au moment de la réservation puis reversée à Plany chaque mois.',
+    CLIENT_PRICE_INFO_LINK: 'ℹ️ Consultez la page {link} pour plus de détails.',
+    CLIENT_PRICE_INFO_LINK_LABEL: 'Gestion des commissions',
     COMMISSION_DETAIL_WITH_AMOUNT: 'Inclut commission Plany, {rate} ({amount})',
     SPECIAL_PRICE_TITLE: 'Tarifs spéciaux par période',
     SPECIAL_PRICE_SUBHEADER: 'Utilisez des plages de dates pour ajuster automatiquement le prix client pendant les temps forts.',
@@ -86,9 +93,16 @@ const strings = new LocalizedStrings({
     AGENCY_PRICE_COLUMN_LABEL: `Agency price (${commonStrings.CURRENCY}${commonStrings.DAILY})`,
     CLIENT_PRICE_COLUMN_LABEL: `Client price (${commonStrings.CURRENCY}${commonStrings.DAILY})`,
     COMMISSION_COLUMN_LABEL: `Commission (${commonStrings.CURRENCY}${commonStrings.DAILY})`,
-    CLIENT_PRICE_INFO_TITLE: 'Client-facing price display',
-    CLIENT_PRICE_INFO_BODY:
-      'Plany calculates the price shown to clients from the agency price by adding the Plany commission. Long-term discounts are then applied on top of the client price. Special prices per period replace the default price whenever they apply.',
+    CLIENT_PRICE_INFO_TITLE: 'Plany commission information',
+    CLIENT_PRICE_INFO_INTRO:
+      'Starting {date} (configurable in the .env file), every booking will include a {rate} commission automatically added by Plany to the agency price you enter.',
+    CLIENT_PRICE_INFO_FORMULA: '👉 Client price displayed = Agency price + Plany commission.',
+    CLIENT_PRICE_INFO_EXAMPLE:
+      'Example: Agency price = {agencyPrice}, commission = {rate} ({commissionAmount}) → Client price = {clientPrice}.',
+    CLIENT_PRICE_INFO_COLLECTION:
+      'The commission is collected by your agency at booking time and then paid back to Plany every month.',
+    CLIENT_PRICE_INFO_LINK: 'ℹ️ See the {link} page for more details.',
+    CLIENT_PRICE_INFO_LINK_LABEL: 'Commission management',
     COMMISSION_DETAIL_WITH_AMOUNT: 'Includes Plany commission, {rate} ({amount})',
     SPECIAL_PRICE_TITLE: 'Special pricing by period',
     SPECIAL_PRICE_SUBHEADER: 'Use date windows to automatically adapt the client price for peak demand.',

--- a/backend/src/pages/CreateCar.tsx
+++ b/backend/src/pages/CreateCar.tsx
@@ -32,6 +32,7 @@ import {
   DialogTitle,
   DialogContent,
   DialogActions,
+  Link,
 } from '@mui/material'
 import {
   Delete as DeleteIcon,
@@ -39,7 +40,7 @@ import {
   Info as InfoIcon,
   AutoAwesome as AutoAwesomeIcon,
 } from '@mui/icons-material'
-import { useNavigate } from 'react-router-dom'
+import { Link as RouterLink, useNavigate } from 'react-router-dom'
 import DateTimePicker from '@/components/DateTimePicker'
 import * as bookcarsTypes from ':bookcars-types'
 import * as bookcarsHelper from ':bookcars-helper'
@@ -143,6 +144,8 @@ const getLocale = (language: string) => {
       return 'en-US'
   }
 }
+
+const COMMISSION_EXAMPLE_PRICE = 70
 
 const CreateCar = () => {
   const navigate = useNavigate()
@@ -248,6 +251,19 @@ const CreateCar = () => {
   }
 
   const commissionRateLabel = `${formatCommissionRate(env.COMMISSION_RATE)}%`
+  const commissionEffectiveDateLabel = new Intl.DateTimeFormat(locale, {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  }).format(env.COMMISSION_EFFECTIVE_DATE)
+  const commissionManagementPath = isSupplier ? '/agency-commissions' : '/admin-commissions'
+  const exampleCommissionInfo = computeCommissionInfo(COMMISSION_EXAMPLE_PRICE)
+  const exampleAgencyPriceLabel = formatPriceWithCurrency(COMMISSION_EXAMPLE_PRICE)
+  const exampleCommissionAmountLabel = formatPriceWithCurrency(
+    exampleCommissionInfo?.commissionValue ?? 0,
+  )
+  const exampleClientPriceLabel = formatPriceWithCurrency(exampleCommissionInfo?.clientPrice ?? 0)
+  const commissionLinkSegments = strings.CLIENT_PRICE_INFO_LINK.split('{link}')
 
   const dailyCommissionInfo = computeCommissionInfo(dailyPrice)
   const newPeriodCommissionInfo = computeCommissionInfo(newPeriod.dailyPrice)
@@ -898,9 +914,29 @@ const CreateCar = () => {
 
             <Alert severity="info" sx={{ mt: 2 }}>
               <Typography fontWeight={600}>{strings.CLIENT_PRICE_INFO_TITLE}</Typography>
-              <Typography variant="body2" sx={{ mt: 1 }}>
-                {strings.CLIENT_PRICE_INFO_BODY}
-              </Typography>
+              <Stack spacing={1} sx={{ mt: 1 }}>
+                <Typography variant="body2">
+                  {strings.CLIENT_PRICE_INFO_INTRO.replace('{date}', commissionEffectiveDateLabel).replace(
+                    '{rate}',
+                    commissionRateLabel,
+                  )}
+                </Typography>
+                <Typography variant="body2">{strings.CLIENT_PRICE_INFO_FORMULA}</Typography>
+                <Typography variant="body2">
+                  {strings.CLIENT_PRICE_INFO_EXAMPLE.replace('{agencyPrice}', exampleAgencyPriceLabel)
+                    .replace('{rate}', commissionRateLabel)
+                    .replace('{commissionAmount}', exampleCommissionAmountLabel)
+                    .replace('{clientPrice}', exampleClientPriceLabel)}
+                </Typography>
+                <Typography variant="body2">{strings.CLIENT_PRICE_INFO_COLLECTION}</Typography>
+                <Typography variant="body2">
+                  {commissionLinkSegments[0] ?? ''}
+                  <Link component={RouterLink} to={commissionManagementPath} underline="hover">
+                    {strings.CLIENT_PRICE_INFO_LINK_LABEL}
+                  </Link>
+                  {commissionLinkSegments[1] ?? ''}
+                </Typography>
+              </Stack>
               {dailyCommissionInfo && (
                 <Box
                   sx={{

--- a/backend/src/pages/UpdateCar.tsx
+++ b/backend/src/pages/UpdateCar.tsx
@@ -32,6 +32,7 @@ import {
   DialogTitle,
   DialogContent,
   DialogActions,
+  Link,
 } from '@mui/material'
 import {
   Delete as DeleteIcon,
@@ -65,6 +66,7 @@ import FuelPolicyList from '@/components/FuelPolicyList'
 import MultimediaList from '@/components/MultimediaList'
 import CarRangeList from '@/components/CarRangeList'
 import { Discount } from ':bookcars-types'
+import { Link as RouterLink } from 'react-router-dom'
 import '@/assets/css/create-car.css'
 
 interface PricePeriod {
@@ -149,6 +151,8 @@ const getLocale = (language: string) => {
       return 'en-US'
   }
 }
+
+const COMMISSION_EXAMPLE_PRICE = 70
 
 const UpdateCar = () => {
   const [user, setUser] = useState<bookcarsTypes.User>()
@@ -269,6 +273,20 @@ const UpdateCar = () => {
   }
 
   const commissionRateLabel = `${formatCommissionRate(env.COMMISSION_RATE)}%`
+  const commissionEffectiveDateLabel = new Intl.DateTimeFormat(locale, {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  }).format(env.COMMISSION_EFFECTIVE_DATE)
+  const commissionManagementPath =
+    user?.type === bookcarsTypes.RecordType.Supplier ? '/agency-commissions' : '/admin-commissions'
+  const exampleCommissionInfo = computeCommissionInfo(COMMISSION_EXAMPLE_PRICE)
+  const exampleAgencyPriceLabel = formatPriceWithCurrency(COMMISSION_EXAMPLE_PRICE)
+  const exampleCommissionAmountLabel = formatPriceWithCurrency(
+    exampleCommissionInfo?.commissionValue ?? 0,
+  )
+  const exampleClientPriceLabel = formatPriceWithCurrency(exampleCommissionInfo?.clientPrice ?? 0)
+  const commissionLinkSegments = strings.CLIENT_PRICE_INFO_LINK.split('{link}')
 
   const dailyCommissionInfo = computeCommissionInfo(dailyPrice)
   const newPeriodCommissionInfo = computeCommissionInfo(newPeriod.dailyPrice)
@@ -1148,14 +1166,34 @@ const discount: Discount | undefined = dayValue && discountValue ? {
                 />
               </FormControl>
 
-              <Alert severity="info" sx={{ mt: 2 }}>
-                <Typography fontWeight={600}>{strings.CLIENT_PRICE_INFO_TITLE}</Typography>
-                <Typography variant="body2" sx={{ mt: 1 }}>
-                  {strings.CLIENT_PRICE_INFO_BODY}
+            <Alert severity="info" sx={{ mt: 2 }}>
+              <Typography fontWeight={600}>{strings.CLIENT_PRICE_INFO_TITLE}</Typography>
+              <Stack spacing={1} sx={{ mt: 1 }}>
+                <Typography variant="body2">
+                  {strings.CLIENT_PRICE_INFO_INTRO.replace('{date}', commissionEffectiveDateLabel).replace(
+                    '{rate}',
+                    commissionRateLabel,
+                  )}
                 </Typography>
-                {dailyCommissionInfo && (
-                  <Box
-                    sx={{
+                <Typography variant="body2">{strings.CLIENT_PRICE_INFO_FORMULA}</Typography>
+                <Typography variant="body2">
+                  {strings.CLIENT_PRICE_INFO_EXAMPLE.replace('{agencyPrice}', exampleAgencyPriceLabel)
+                    .replace('{rate}', commissionRateLabel)
+                    .replace('{commissionAmount}', exampleCommissionAmountLabel)
+                    .replace('{clientPrice}', exampleClientPriceLabel)}
+                </Typography>
+                <Typography variant="body2">{strings.CLIENT_PRICE_INFO_COLLECTION}</Typography>
+                <Typography variant="body2">
+                  {commissionLinkSegments[0] ?? ''}
+                  <Link component={RouterLink} to={commissionManagementPath} underline="hover">
+                    {strings.CLIENT_PRICE_INFO_LINK_LABEL}
+                  </Link>
+                  {commissionLinkSegments[1] ?? ''}
+                </Typography>
+              </Stack>
+              {dailyCommissionInfo && (
+                <Box
+                  sx={{
                       mt: 2,
                       display: 'flex',
                       flexDirection: isMobile ? 'column' : 'row',


### PR DESCRIPTION
## Summary
- refresh the create/update car translations to describe the upcoming Plany commission with configurable placeholders
- enrich the commission alert on the car pricing forms with dynamic dates, example figures, and a link to the commission management page

## Testing
- npm run lint *(fails: ESLint couldn't find an eslint.config file in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9330001008333a37e11745ed8cbfa