### PR TITLE
Add cross-portal guidance to sign-up pages

### DIFF
--- a/backend/src/assets/css/signup.css
+++ b/backend/src/assets/css/signup.css
@@ -5,7 +5,15 @@ div.signup {
   flex: 1 0 auto;
   justify-content: center;
   margin: 45px 0;
+  padding: 0 16px;
   transform: translate3d(0, 0, 0);
+}
+
+div.signup .signup-form {
+  box-sizing: border-box;
+  max-width: 560px;
+  padding: 30px;
+  width: 100%;
 }
 
 .signup-form-title {
@@ -14,28 +22,8 @@ div.signup {
   color: #121212;
 }
 
-.signup-portal-info {
-  align-items: center;
-  background-color: #f5f5f5;
-  border-radius: 8px;
-  display: flex;
-  gap: 12px;
-  justify-content: space-between;
-  margin-bottom: 20px;
-  margin-top: 10px;
-  padding: 12px 16px;
-}
-
-.signup-portal-info p {
-  color: #121212;
-  flex: 1 1 auto;
-  font-size: 0.95rem;
-  margin: 0;
-}
-
-.signup-portal-info button {
-  flex-shrink: 0;
-  white-space: nowrap;
+.signup-portal-alert {
+  margin: 16px 0 24px;
 }
 
 .signup .buttons {
@@ -52,10 +40,15 @@ div.signup {
 /* Device width is less than or equal to 960px */
 
 @media only screen and (max-width: 960px) {
+  div.signup {
+    flex-direction: column;
+    margin: 32px 0;
+  }
+
   .signup-form {
-    width: 350px;
     height: 730px;
-    padding: 30px;
+    max-width: 420px;
+    padding: 24px;
   }
 
   .recaptcha {
@@ -64,13 +57,29 @@ div.signup {
   }
 }
 
+@media only screen and (max-width: 600px) {
+  div.signup {
+    margin: 20px 0;
+    padding: 0 12px;
+  }
+
+  .signup-form {
+    height: auto;
+    max-width: none;
+    padding: 20px;
+  }
+
+  .recaptcha {
+    margin-left: 0;
+  }
+}
+
 /* Device width is greater than or equal to 960px */
 
 @media only screen and (min-width: 960px) {
   .signup-form {
-    width: 550px;
+    max-width: 550px;
     height: 610px;
-    padding: 30px;
   }
 
   .recaptcha {

--- a/backend/src/assets/css/signup.css
+++ b/backend/src/assets/css/signup.css
@@ -14,6 +14,30 @@ div.signup {
   color: #121212;
 }
 
+.signup-portal-info {
+  align-items: center;
+  background-color: #f5f5f5;
+  border-radius: 8px;
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+  margin-bottom: 20px;
+  margin-top: 10px;
+  padding: 12px 16px;
+}
+
+.signup-portal-info p {
+  color: #121212;
+  flex: 1 1 auto;
+  font-size: 0.95rem;
+  margin: 0;
+}
+
+.signup-portal-info button {
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
 .signup .buttons {
   float: right;
   margin-top: 15px;

--- a/backend/src/lang/sign-up.ts
+++ b/backend/src/lang/sign-up.ts
@@ -8,6 +8,8 @@ const strings = new LocalizedStrings({
     SIGN_UP: "S'inscrire",
     RECAPTCHA_ERROR: 'Veuillez remplir le captcha pour continuer.',
     SIGN_UP_ERROR: "Une erreur s'est produite lors de l'inscription.",
+    CUSTOMER_SIGNUP_INFO: 'Vous êtes un client ? Rejoignez la plateforme de réservation.',
+    CUSTOMER_SIGNUP_BUTTON: 'Inscription client',
   },
   en: {
     SIGN_UP_HEADING: 'Sign up',
@@ -15,6 +17,8 @@ const strings = new LocalizedStrings({
     SIGN_UP: 'Sign up',
     RECAPTCHA_ERROR: 'Fill out the captcha to continue.',
     SIGN_UP_ERROR: 'An error occurred during sign up.',
+    CUSTOMER_SIGNUP_INFO: 'Looking for the customer portal? Continue on the booking website.',
+    CUSTOMER_SIGNUP_BUTTON: 'Sign up as a customer',
   },
 })
 

--- a/backend/src/pages/SignUp.tsx
+++ b/backend/src/pages/SignUp.tsx
@@ -5,7 +5,8 @@ import {
   FormControl,
   FormHelperText,
   Button,
-  Paper
+  Paper,
+  Alert,
 } from '@mui/material'
 import validator from 'validator'
 import { useNavigate } from 'react-router-dom'
@@ -170,17 +171,21 @@ const SignUp = () => {
             {strings.SIGN_UP_HEADING}
             {' '}
           </h1>
-          <div className="signup-portal-info">
-            <p>{strings.CUSTOMER_SIGNUP_INFO}</p>
-            <Button
-              variant="outlined"
-              color="primary"
-              size="small"
-              href="https://plany.tn/sign-up"
-            >
-              {strings.CUSTOMER_SIGNUP_BUTTON}
-            </Button>
-          </div>
+          <Alert
+            severity="info"
+            className="signup-portal-alert"
+            action={(
+              <Button
+                color="inherit"
+                size="small"
+                href="https://plany.tn/sign-up"
+              >
+                {strings.CUSTOMER_SIGNUP_BUTTON}
+              </Button>
+            )}
+          >
+            {strings.CUSTOMER_SIGNUP_INFO}
+          </Alert>
           <form onSubmit={handleSubmit}>
             <div>
               <FormControl fullWidth margin="dense">

--- a/backend/src/pages/SignUp.tsx
+++ b/backend/src/pages/SignUp.tsx
@@ -170,6 +170,17 @@ const SignUp = () => {
             {strings.SIGN_UP_HEADING}
             {' '}
           </h1>
+          <div className="signup-portal-info">
+            <p>{strings.CUSTOMER_SIGNUP_INFO}</p>
+            <Button
+              variant="outlined"
+              color="primary"
+              size="small"
+              href="https://plany.tn/sign-up"
+            >
+              {strings.CUSTOMER_SIGNUP_BUTTON}
+            </Button>
+          </div>
           <form onSubmit={handleSubmit}>
             <div>
               <FormControl fullWidth margin="dense">

--- a/frontend/src/assets/css/signup.css
+++ b/frontend/src/assets/css/signup.css
@@ -19,6 +19,30 @@ div.signup .signup-form-title {
   color: #232323;
 }
 
+div.signup .signup-portal-info {
+  align-items: center;
+  background-color: #f5f5f5;
+  border-radius: 8px;
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+  margin-bottom: 20px;
+  margin-top: 10px;
+  padding: 12px 16px;
+}
+
+div.signup .signup-portal-info p {
+  color: #232323;
+  flex: 1 1 auto;
+  font-size: 0.95rem;
+  margin: 0;
+}
+
+div.signup .signup-portal-info button {
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
 div.signup div.signup-tos {
   margin-top: 10px;
 }

--- a/frontend/src/assets/css/signup.css
+++ b/frontend/src/assets/css/signup.css
@@ -9,8 +9,16 @@ div.signup {
   justify-content: center;
   -webkit-justify-content: center;
   margin: 45px 0;
+  padding: 0 16px;
   transform: translate3d(0, 0, 0);
   -webkit-transform: translate3d(0, 0, 0);
+}
+
+div.signup .signup-form {
+  box-sizing: border-box;
+  padding: 30px;
+  width: 100%;
+  max-width: 560px;
 }
 
 div.signup .signup-form-title {
@@ -19,28 +27,8 @@ div.signup .signup-form-title {
   color: #232323;
 }
 
-div.signup .signup-portal-info {
-  align-items: center;
-  background-color: #f5f5f5;
-  border-radius: 8px;
-  display: flex;
-  gap: 12px;
-  justify-content: space-between;
-  margin-bottom: 20px;
-  margin-top: 10px;
-  padding: 12px 16px;
-}
-
-div.signup .signup-portal-info p {
-  color: #232323;
-  flex: 1 1 auto;
-  font-size: 0.95rem;
-  margin: 0;
-}
-
-div.signup .signup-portal-info button {
-  flex-shrink: 0;
-  white-space: nowrap;
+div.signup .signup-portal-alert {
+  margin: 16px 0 24px;
 }
 
 div.signup div.signup-tos {
@@ -50,14 +38,36 @@ div.signup div.signup-tos {
 /* Device width is less than or equal to 960px */
 
 @media only screen and (max-width: 960px) {
+  div.signup {
+    flex-direction: column;
+    -webkit-flex-direction: column;
+    margin: 32px 0;
+  }
+
   div.signup .signup-form {
-    width: 350px;
-    padding: 30px;
+    max-width: 420px;
+    padding: 24px;
   }
 
   div.signup .recaptcha {
     margin-top: 25px;
     margin-left: -10px;
+  }
+}
+
+@media only screen and (max-width: 600px) {
+  div.signup {
+    margin: 20px 0;
+    padding: 0 12px;
+  }
+
+  div.signup .signup-form {
+    max-width: none;
+    padding: 20px;
+  }
+
+  div.signup .recaptcha {
+    margin-left: 0;
   }
 }
 
@@ -86,8 +96,7 @@ div.signup div.signup-buttons button {
 
 @media only screen and (min-width: 960px) {
   div.signup .signup-form {
-    width: 550px;
-    padding: 30px;
+    max-width: 550px;
   }
 
   div.signup .recaptcha {

--- a/frontend/src/lang/sign-up.ts
+++ b/frontend/src/lang/sign-up.ts
@@ -6,11 +6,15 @@ const strings = new LocalizedStrings({
     SIGN_UP_HEADING: 'Inscription',
     SIGN_UP: "S'inscrire",
     SIGN_UP_ERROR: "Une erreur s'est produite lors de l'inscription.",
+    AGENCY_SIGNUP_INFO: 'Vous êtes une agence ? Accédez à la plateforme dédiée.',
+    AGENCY_SIGNUP_BUTTON: 'Inscrire mon agence',
   },
   en: {
     SIGN_UP_HEADING: 'Sign up',
     SIGN_UP: 'Sign up',
     SIGN_UP_ERROR: 'An error occurred during sign up.',
+    AGENCY_SIGNUP_INFO: 'Are you an agency? Switch to the dedicated portal.',
+    AGENCY_SIGNUP_BUTTON: 'Register as an agency',
   },
 })
 

--- a/frontend/src/pages/SignUp.tsx
+++ b/frontend/src/pages/SignUp.tsx
@@ -336,6 +336,17 @@ const SignUp = () => {
           <div className="signup">
             <Paper className="signup-form" elevation={10}>
               <h1 className="signup-form-title">{strings.SIGN_UP_HEADING}</h1>
+              <div className="signup-portal-info">
+                <p>{strings.AGENCY_SIGNUP_INFO}</p>
+                <Button
+                  variant="outlined"
+                  color="primary"
+                  size="small"
+                  href="https://admin.plany.tn/sign-up"
+                >
+                  {strings.AGENCY_SIGNUP_BUTTON}
+                </Button>
+              </div>
               <form onSubmit={handleSubmit}>
                 <div>
                   <FormControl fullWidth margin="dense">

--- a/frontend/src/pages/SignUp.tsx
+++ b/frontend/src/pages/SignUp.tsx
@@ -9,6 +9,7 @@ import {
   Paper,
   Checkbox,
   Link,
+  Alert,
 } from '@mui/material'
 import validator from 'validator'
 import { intervalToDuration } from 'date-fns'
@@ -336,17 +337,21 @@ const SignUp = () => {
           <div className="signup">
             <Paper className="signup-form" elevation={10}>
               <h1 className="signup-form-title">{strings.SIGN_UP_HEADING}</h1>
-              <div className="signup-portal-info">
-                <p>{strings.AGENCY_SIGNUP_INFO}</p>
-                <Button
-                  variant="outlined"
-                  color="primary"
-                  size="small"
-                  href="https://admin.plany.tn/sign-up"
-                >
-                  {strings.AGENCY_SIGNUP_BUTTON}
-                </Button>
-              </div>
+              <Alert
+                severity="info"
+                className="signup-portal-alert"
+                action={(
+                  <Button
+                    color="inherit"
+                    size="small"
+                    href="https://admin.plany.tn/sign-up"
+                  >
+                    {strings.AGENCY_SIGNUP_BUTTON}
+                  </Button>
+                )}
+              >
+                {strings.AGENCY_SIGNUP_INFO}
+              </Alert>
               <form onSubmit={handleSubmit}>
                 <div>
                   <FormControl fullWidth margin="dense">


### PR DESCRIPTION
## Summary
- add localized informational banner on the customer sign-up page linking to the agency portal
- add localized informational banner on the agency sign-up page linking back to the customer portal
- style the new banners consistently across both frontend and backend sign-up views

## Testing
- npm run lint (frontend)
- npm run lint (backend) *(fails: ESLint 9 requires eslint.config.js in this workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68d9918941288333bffdefcadf42816c