### PR TITLE
Add unit tests for commission workflows

### DIFF
--- a/api/tests/commissionController.test.ts
+++ b/api/tests/commissionController.test.ts
@@ -1,0 +1,194 @@
+import { jest } from '@jest/globals'
+import type { Request, Response } from 'express'
+import mongoose from 'mongoose'
+import * as bookcarsTypes from ':bookcars-types'
+import AgencyCommissionSettings from '../src/models/AgencyCommissionSettings'
+import * as authHelper from '../src/common/authHelper'
+import User from '../src/models/User'
+import * as env from '../src/config/env.config'
+import { getCommissionSettings, updateCommissionSettings } from '../src/controllers/commissionController'
+
+const createMockResponse = () => {
+  const res = {
+    status: jest.fn().mockReturnThis(),
+    send: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+    setHeader: jest.fn(),
+  }
+  return res as unknown as Response & {
+    status: jest.Mock
+    send: jest.Mock
+    json: jest.Mock
+    setHeader: jest.Mock
+  }
+}
+
+const createRequestWithToken = async (
+  userId: string,
+  overrides: Partial<Request> = {},
+) => {
+  const token = await authHelper.encryptJWT({ id: userId })
+  const req = {
+    headers: { [env.X_ACCESS_TOKEN]: token },
+    signedCookies: {},
+    params: {},
+    body: {},
+    ...overrides,
+  }
+  return req as Request
+}
+
+describe('commissionController settings endpoints', () => {
+  const adminId = new mongoose.Types.ObjectId().toString()
+  const updatedById = new mongoose.Types.ObjectId().toString()
+  const nonAdminId = new mongoose.Types.ObjectId().toString()
+
+  const adminUser = {
+    _id: adminId,
+    type: bookcarsTypes.UserType.Admin,
+    fullName: 'Admin User',
+    email: 'admin@example.com',
+    language: 'fr',
+    score: 0,
+  } as unknown as env.User
+
+  const nonAdminUser = {
+    _id: nonAdminId,
+    type: bookcarsTypes.UserType.Supplier,
+    fullName: 'Supplier User',
+    email: 'supplier@example.com',
+    language: 'fr',
+    score: 0,
+  } as unknown as env.User
+
+  const updatedByUser = {
+    _id: updatedById,
+    type: bookcarsTypes.UserType.Admin,
+    fullName: 'Moderator',
+    email: 'moderator@example.com',
+    phone: '+21600000000',
+    slug: 'moderator',
+    language: 'fr',
+    score: 0,
+  } as unknown as env.User
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+    jest.clearAllMocks()
+  })
+
+  it('should deny access when the requester is not an admin', async () => {
+    const findByIdMock = jest.spyOn(User, 'findById') as unknown as jest.Mock
+    findByIdMock.mockImplementation((...args: unknown[]) => {
+      const [id] = args as [string]
+      if (id === nonAdminId) {
+        return Promise.resolve(nonAdminUser)
+      }
+      return Promise.resolve(null)
+    })
+
+    const req = await createRequestWithToken(nonAdminId)
+    const res = createMockResponse()
+
+    await getCommissionSettings(req, res)
+
+    expect(res.status).toHaveBeenCalledWith(403)
+  })
+
+  it('should return persisted commission settings with metadata', async () => {
+    const findByIdMock = jest.spyOn(User, 'findById') as unknown as jest.Mock
+    findByIdMock.mockImplementation((...args: unknown[]) => {
+      const [rawId] = args as [mongoose.Types.ObjectId | string]
+      const id = typeof rawId === 'string' ? rawId : rawId.toString()
+      if (id === adminId) {
+        return Promise.resolve(adminUser)
+      }
+      if (id === updatedById) {
+        return Promise.resolve(updatedByUser)
+      }
+      return Promise.resolve(null)
+    })
+
+    const settingsDocument = new AgencyCommissionSettings({
+      reminderChannel: bookcarsTypes.CommissionReminderChannel.Sms,
+      emailTemplate: 'Email template',
+      smsTemplate: 'Sms template',
+      updatedBy: new mongoose.Types.ObjectId(updatedById),
+    })
+    settingsDocument.updatedAt = new Date()
+    jest.spyOn(AgencyCommissionSettings, 'findOne').mockResolvedValue(settingsDocument)
+
+    const req = await createRequestWithToken(adminId)
+    const res = createMockResponse()
+
+    await getCommissionSettings(req, res)
+
+    expect(res.json).toHaveBeenCalled()
+    const payload = res.json.mock.calls[0][0] as bookcarsTypes.CommissionSettings
+    expect(payload).toMatchObject({
+      reminderChannel: bookcarsTypes.CommissionReminderChannel.Sms,
+      emailTemplate: 'Email template',
+      smsTemplate: 'Sms template',
+    })
+    expect(payload.updatedBy).toMatchObject({
+      id: updatedById,
+      name: updatedByUser.fullName,
+      email: updatedByUser.email,
+    })
+  })
+
+  it('should validate required fields when updating settings', async () => {
+    const findByIdMock = jest.spyOn(User, 'findById') as unknown as jest.Mock
+    findByIdMock.mockImplementation(() => Promise.resolve(adminUser))
+
+    const req = await createRequestWithToken(adminId, { body: {} })
+    const res = createMockResponse()
+
+    await updateCommissionSettings(req, res)
+
+    expect(res.status).toHaveBeenCalledWith(400)
+  })
+
+  it('should persist updated commission settings', async () => {
+    const findByIdMock = jest.spyOn(User, 'findById') as unknown as jest.Mock
+    findByIdMock.mockImplementation((...args: unknown[]) => {
+      const [rawId] = args as [mongoose.Types.ObjectId | string]
+      const id = typeof rawId === 'string' ? rawId : rawId.toString()
+      if (id === adminId) {
+        return Promise.resolve(adminUser)
+      }
+      if (id === updatedById) {
+        return Promise.resolve(updatedByUser)
+      }
+      return Promise.resolve(null)
+    })
+
+    const settingsDocument = new AgencyCommissionSettings({
+      reminderChannel: bookcarsTypes.CommissionReminderChannel.Email,
+      emailTemplate: 'Initial email',
+      smsTemplate: 'Initial sms',
+      updatedBy: new mongoose.Types.ObjectId(updatedById),
+    })
+    settingsDocument.updatedAt = new Date()
+    ;(settingsDocument as any).save = jest.fn(async () => settingsDocument)
+    jest.spyOn(AgencyCommissionSettings, 'findOne').mockResolvedValue(settingsDocument)
+
+    const req = await createRequestWithToken(adminId, {
+      body: {
+        reminderChannel: bookcarsTypes.CommissionReminderChannel.Email,
+        emailTemplate: 'Updated email body',
+        smsTemplate: 'Updated sms body',
+      },
+    })
+    const res = createMockResponse()
+
+    await updateCommissionSettings(req, res)
+
+    expect(settingsDocument.save).toHaveBeenCalledTimes(1)
+    expect(settingsDocument.emailTemplate).toBe('Updated email body')
+    expect(settingsDocument.smsTemplate).toBe('Updated sms body')
+    expect(res.json).toHaveBeenCalled()
+    const payload = res.json.mock.calls[0][0] as bookcarsTypes.CommissionSettings
+    expect(payload.updatedBy).toMatchObject({ id: adminId, name: adminUser.fullName })
+  })
+})

--- a/api/tests/commissionModels.test.ts
+++ b/api/tests/commissionModels.test.ts
@@ -1,0 +1,103 @@
+import mongoose from 'mongoose'
+import * as bookcarsTypes from ':bookcars-types'
+import AgencyCommissionEvent from '../src/models/AgencyCommissionEvent'
+import AgencyCommissionSettings from '../src/models/AgencyCommissionSettings'
+import AgencyCommissionState from '../src/models/AgencyCommissionState'
+
+describe('AgencyCommissionSettings model', () => {
+  it('should provide default reminder channel and templates', () => {
+    const settings = new AgencyCommissionSettings()
+
+    expect(settings.reminderChannel).toBe(bookcarsTypes.CommissionReminderChannel.Email)
+    expect(settings.emailTemplate).toContain('{{amount}}')
+    expect(settings.smsTemplate).toContain('{{amount}}')
+  })
+
+  it('should reject unsupported reminder channels', () => {
+    const settings = new AgencyCommissionSettings({
+      reminderChannel: 'invalid-channel' as bookcarsTypes.CommissionReminderChannel,
+    })
+
+    const validationError = settings.validateSync()
+
+    expect(validationError?.errors.reminderChannel).toBeDefined()
+  })
+
+  it('should reference users in the updatedBy field', () => {
+    const updatedByPath = AgencyCommissionSettings.schema.path('updatedBy')
+
+    expect(updatedByPath?.options.ref).toBe('User')
+  })
+})
+
+describe('AgencyCommissionState model', () => {
+  it('should require an agency identifier', () => {
+    const state = new AgencyCommissionState()
+
+    const validationError = state.validateSync()
+
+    expect(validationError?.errors.agency).toBeDefined()
+  })
+
+  it('should default blocked flag to false', () => {
+    const state = new AgencyCommissionState({
+      agency: new mongoose.Types.ObjectId(),
+    })
+
+    expect(state.blocked).toBe(false)
+  })
+
+  it('should allow storing disabled cars as object ids', () => {
+    const carId = new mongoose.Types.ObjectId()
+    const state = new AgencyCommissionState({
+      agency: new mongoose.Types.ObjectId(),
+      disabledCars: [carId],
+    })
+
+    const validationError = state.validateSync()
+
+    expect(validationError).toBeUndefined()
+    expect(state.disabledCars).toEqual([carId])
+  })
+})
+
+describe('AgencyCommissionEvent model', () => {
+  it('should enforce mandatory event fields', () => {
+    const event = new AgencyCommissionEvent()
+
+    const validationError = event.validateSync()
+
+    expect(validationError?.errors.agency).toBeDefined()
+    expect(validationError?.errors.month).toBeDefined()
+    expect(validationError?.errors.year).toBeDefined()
+    expect(validationError?.errors.type).toBeDefined()
+    expect(validationError?.errors.admin).toBeDefined()
+  })
+
+  it('should default the amount to zero when omitted', () => {
+    const event = new AgencyCommissionEvent({
+      agency: new mongoose.Types.ObjectId(),
+      month: 5,
+      year: 2024,
+      type: bookcarsTypes.AgencyCommissionEventType.Payment,
+      admin: new mongoose.Types.ObjectId(),
+    })
+
+    expect(event.amount).toBe(0)
+    const validationError = event.validateSync()
+    expect(validationError).toBeUndefined()
+  })
+
+  it('should expose a compound index to prevent duplicate events', () => {
+    const indexes = AgencyCommissionEvent.schema.indexes()
+
+    const hasCompoundIndex = indexes.some(([fields]) => (
+      fields.agency === 1
+      && fields.month === 1
+      && fields.year === 1
+      && fields.type === 1
+    ))
+
+    expect(hasCompoundIndex).toBe(true)
+  })
+})

--- a/api/tests/commissionRoutes.test.ts
+++ b/api/tests/commissionRoutes.test.ts
@@ -1,0 +1,28 @@
+import routes from '../src/config/commissionRoutes.config'
+
+describe('commissionRoutes.config', () => {
+  it('should expose the full set of commission endpoints', () => {
+    expect(routes).toMatchObject({
+      getList: '/api/commission/list/:page/:size',
+      exportList: '/api/commission/export/:page/:size',
+      getDetails: '/api/commission/details/:agencyId/:year/:month',
+      sendReminder: '/api/commission/reminder',
+      recordPayment: '/api/commission/payment',
+      toggleBlock: '/api/commission/block',
+      addNote: '/api/commission/note',
+      getSettings: '/api/commission/settings',
+      updateSettings: '/api/commission/settings',
+      generateInvoice: '/api/commission/invoice/:agencyId/:year/:month',
+      getAgencyBookings: '/api/commission/agency/bookings',
+      downloadAgencyInvoice: '/api/commission/agency/:agencyId/invoice/:year/:month',
+      downloadAgencyBookingInvoice: '/api/commission/agency/invoice/booking/:bookingId',
+    })
+  })
+
+  it('should only duplicate routes for shared read/write endpoints', () => {
+    const values = Object.values(routes)
+    const duplicates = values.filter((value, index) => values.indexOf(value) !== index)
+
+    expect(new Set(duplicates)).toEqual(new Set([routes.getSettings]))
+  })
+})


### PR DESCRIPTION
## Summary
- add coverage for commission settings controller access and update flows
- verify commission route mappings and agency commission Mongoose models

## Testing
- npm test -- --runTestsByPath tests/commissionModels.test.ts tests/commissionRoutes.test.ts tests/commissionController.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d9967a39ec833394d06b63f5df685a