### PR TITLE
fix(backend): add flat eslint config compatibility

### DIFF
--- a/backend/eslint.config.js
+++ b/backend/eslint.config.js
@@ -1,0 +1,84 @@
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { FlatCompat } from 'eslint/use-at-your-own-risk'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+})
+
+export default [
+  ...compat.config({
+    root: true,
+    env: { browser: true, es2020: true },
+    extends: [
+      'airbnb',
+      'eslint:recommended',
+      'plugin:@typescript-eslint/recommended',
+      'plugin:react-hooks/recommended',
+    ],
+    ignorePatterns: ['dist', '.eslintrc.cjs', 'vite.config.d.ts', 'vite.config.js'],
+    parser: '@typescript-eslint/parser',
+    plugins: ['react-refresh'],
+    rules: {
+      'semi': [
+        'error',
+        'never',
+      ],
+      'brace-style': [
+        'error',
+        '1tbs',
+      ],
+      'react-hooks/exhaustive-deps': 'warn',
+      'react-refresh/only-export-components': [
+        'warn',
+        { allowConstantExport: true },
+      ],
+      'react/jsx-filename-extension': [
+        'warn',
+        {
+          'extensions': [
+            '.tsx',
+            '.ts',
+          ],
+        },
+      ],
+      'react/function-component-definition': [
+        'warn',
+        {
+          'namedComponents': 'arrow-function',
+        },
+      ],
+      'curly': 'error',
+      'linebreak-style': 'off',
+      'no-underscore-dangle': 'off',
+      'no-restricted-syntax': 'off',
+      'import/no-unresolved': 'off',
+      'import/extensions': 'off',
+      'max-len': 'off',
+      'indent': 'off',
+      'import/prefer-default-export': 'off',
+      'no-await-in-loop': 'off',
+      'comma-dangle': 'off',
+      'implicit-arrow-linebreak': 'off',
+      'func-names': 'off',
+      'jsx-a11y/no-noninteractive-element-interactions': 'off',
+      'jsx-a11y/click-events-have-key-events': 'off',
+      'no-param-reassign': 'off',
+      'react/require-default-props': 'off',
+      'react/jsx-props-no-spreading': 'off',
+      'react/display-name': 'off',
+      'no-nested-ternary': 'off',
+      'react/jsx-no-useless-fragment': 'off',
+      'object-curly-newline': 'off',
+      'no-empty-function': 'off',
+      '@typescript-eslint/no-empty-function': 'off',
+      'react/prop-types': 'off',
+      'no-console': 'off',
+      '@typescript-eslint/no-explicit-any': 'off',
+      'import/no-extraneous-dependencies': 'off',
+    },
+  }),
+]


### PR DESCRIPTION
## Summary
- add a flat-config-based ESLint setup so the backend app works with ESLint 9

## Testing
- not run (npm registry access is blocked in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68d999edb0208333b57a4b09dba916c3