### PR TITLE
fix: reconcile user document typing

### DIFF
--- a/api/src/common/helper.ts
+++ b/api/src/common/helper.ts
@@ -6,6 +6,7 @@ import Stripe from 'stripe'
 import { nanoid } from 'nanoid'
 import axios from 'axios'
 import * as bookcarsTypes from ':bookcars-types'
+import type { User as EnvUser } from '../config/env.config'
 import i18n from '../lang/i18n'
 
 /**
@@ -265,9 +266,9 @@ export const validateAccessToken = async (socialSignInType: bookcarsTypes.Social
   return false
 }
 
-export const admin = (user?: bookcarsTypes.User): boolean => (user && user.type === bookcarsTypes.RecordType.Admin) ?? false
+export const admin = (user?: (bookcarsTypes.User | EnvUser) | null): boolean => user?.type === bookcarsTypes.RecordType.Admin
 
-export const supplier = (user?: bookcarsTypes.User): boolean => (user && user.type === bookcarsTypes.RecordType.Supplier) ?? false
+export const supplier = (user?: (bookcarsTypes.User | EnvUser) | null): boolean => user?.type === bookcarsTypes.RecordType.Supplier
 
 const SCORE_CONFIG = {
   PHONE_MAX: 10, // Points maximum pour le téléphone
@@ -365,7 +366,11 @@ interface ScoreBreakdown {
    * @param {Car[]} cars
    * @returns {ScoreBreakdown}
    */
-  export function calculateAgencyScore(agency: bookcarsTypes.User, bookings: bookcarsTypes.Booking[], cars: bookcarsTypes.Car[]): ScoreBreakdown {
+  export function calculateAgencyScore(
+    agency: bookcarsTypes.User | EnvUser,
+    bookings: bookcarsTypes.Booking[],
+    cars: bookcarsTypes.Car[],
+  ): ScoreBreakdown {
     const breakdown: ScoreBreakdown = {
       total: 0,
       details: {

--- a/api/src/common/invoiceHelper.ts
+++ b/api/src/common/invoiceHelper.ts
@@ -27,7 +27,7 @@ const getPrice = (
 
 export const generateInvoice = async (
   subscription: bookcarsTypes.Subscription,
-  supplier: bookcarsTypes.User,
+  supplier: Pick<bookcarsTypes.User, 'fullName' | 'email'>,
 ) => {
   if (!subscription.invoice) {
     throw new Error('invoice filename missing')

--- a/api/src/controllers/subscriptionController.ts
+++ b/api/src/controllers/subscriptionController.ts
@@ -10,6 +10,7 @@ import * as helper from '../common/helper'
 import * as mailHelper from '../common/mailHelper'
 import * as invoiceHelper from '../common/invoiceHelper'
 import * as env from '../config/env.config'
+import type { User as EnvUser } from '../config/env.config'
 
 export const create = async (req: Request, res: Response) => {
   try {
@@ -37,7 +38,7 @@ export const create = async (req: Request, res: Response) => {
     if (supplier) {
       await invoiceHelper.generateInvoice(
         subscription.toObject() as bookcarsTypes.Subscription,
-        supplier.toObject() as bookcarsTypes.User,
+        { fullName: supplier.fullName, email: supplier.email },
       )
 
       const file = path.join(env.CDN_INVOICES, subscription.invoice)
@@ -121,7 +122,7 @@ export const create = async (req: Request, res: Response) => {
 export const getSubscriptions = async (req: Request, res: Response) => {
   try {
     const sessionData = await authHelper.getSessionData(req)
-    const connectedUser: bookcarsTypes.User|null = await User.findById(sessionData.id)
+    const connectedUser: EnvUser | null = await User.findById(sessionData.id)
     const isAdmin = connectedUser ? helper.admin(connectedUser) : false
     if (!isAdmin) {
       return res.sendStatus(403)
@@ -146,7 +147,7 @@ export const update = async (req: Request, res: Response) => {
   try {
     const { body } = req
     const sessionData = await authHelper.getSessionData(req)
-    const connectedUser: bookcarsTypes.User|null = await User.findById(sessionData.id)
+    const connectedUser: EnvUser | null = await User.findById(sessionData.id)
     const isAdmin = connectedUser ? helper.admin(connectedUser) : false
     if (!isAdmin) {
       return res.sendStatus(403)


### PR DESCRIPTION
## Summary
- allow helper utilities to accept Mongoose user documents alongside shared user types
- remove unsafe casts in user, supplier, and subscription controllers while normalizing ID comparisons
- adjust invoice generation to use minimal supplier details when producing subscription invoices

## Testing
- npm run build (api)


------
https://chatgpt.com/codex/tasks/task_e_68dae26d7a288333927bca938142e1d9