### PR TITLE
fix: improve user list mobile layout

### DIFF
--- a/backend/src/assets/css/user-list.css
+++ b/backend/src/assets/css/user-list.css
@@ -39,12 +39,17 @@ div.us-list span.bp {
 
 div.us-list a.us-user {
   display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  width: 100%;
 }
 
 div.us-list span.us-avatar {
   margin-right: 5px;
   width: 60px;
   height: 30px;
+  flex-shrink: 0;
 }
 
 div.us-list span.us-avatar img {
@@ -67,14 +72,24 @@ div.us-list span.us-avatar img.supplier-avatar-placeholder {
 }
 
 div.us-list div.us-actions {
-  display: inline-flex;
+  display: flex;
   align-items: center;
   gap: 4px;
+  justify-content: flex-end;
+  width: 100%;
 }
 
 div.us-list div.us-actions-header {
   width: 100%;
   justify-content: flex-end;
+}
+
+div.us-list span.us-name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 @media (max-width: 600px) {

--- a/backend/src/components/UserList.tsx
+++ b/backend/src/components/UserList.tsx
@@ -202,6 +202,8 @@ const UserList = ({
   }
 
   const getColumns = (_user: bookcarsTypes.User): GridColDef<bookcarsTypes.User>[] => {
+    const actionColumnMinWidth = env.isMobile() ? 140 : 180
+
     const _columns: GridColDef<bookcarsTypes.User>[] = [
       {
         field: 'fullName',
@@ -340,7 +342,7 @@ const UserList = ({
           return (
             <Link href={`/user?u=${row._id}`} className="us-user">
               <span className="us-avatar">{userAvatar}</span>
-              <span>{value}</span>
+              <span className="us-name">{value}</span>
             </Link>
           )
         },
@@ -370,7 +372,7 @@ const UserList = ({
         headerName: '',
         sortable: false,
         disableColumnMenu: true,
-        minWidth: 180,
+        minWidth: actionColumnMinWidth,
         flex: 0,
         renderCell: ({ row }: GridRenderCellParams<bookcarsTypes.User>) => {
           const handleDelete = (e: React.MouseEvent<HTMLElement>) => {
@@ -401,7 +403,7 @@ const UserList = ({
             : strings.CHANGE_TYPE_TO_USER
 
           return (
-            <div className="us-actions">
+            <Box className="us-actions">
               <Tooltip title={commonStrings.UPDATE}>
                 <IconButton href={`update-user?u=${row._id}`}>
                   <EditIcon />
@@ -422,7 +424,7 @@ const UserList = ({
                   <DeleteIcon />
                 </IconButton>
               </Tooltip>
-            </div>
+            </Box>
           )
         },
         renderHeader: () => (selectedIds.length > 0 ? (


### PR DESCRIPTION
## Summary
- refine the user list layout so avatars and names align and truncate correctly on mobile
- align the action toolbar within a flex container and shrink the column width on small screens

## Testing
- npm run lint *(fails: Cannot find package 'eslint' imported from /workspace/bookcars/backend/eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68daf2edd1448333a3828a997949318f